### PR TITLE
fix: force overall healthScoreV2/healthLabel null for korg (IN-1244)

### DIFF
--- a/services/libs/tinybird/pipes/org_page_contributors.pipe
+++ b/services/libs/tinybird/pipes/org_page_contributors.pipe
@@ -92,8 +92,10 @@ SQL >
             FROM activityRelations_deduplicated_cleaned_bucket_union
             WHERE
                 organizationId = (SELECT id FROM org_slug_lookup)
-                {% if defined(startDate) %} AND timestamp >= {{ DateTime(startDate) }} {% end %}
-                {% if defined(endDate) %} AND timestamp < {{ DateTime(endDate) }} {% end %}
+                {% if defined(startDate) %} AND timestamp >= {{ DateTime(startDate) }}
+                {% end %}
+                {% if defined(endDate) %} AND timestamp < {{ DateTime(endDate) }}
+                {% end %}
         {% end %}
     {% else %}
         SELECT

--- a/services/libs/tinybird/pipes/project_insights_copy.pipe
+++ b/services/libs/tinybird/pipes/project_insights_copy.pipe
@@ -188,7 +188,8 @@ SQL >
         pm.activeOrganizationsPrevious365Days AS activeOrganizationsPrevious365Days,
         -- shortcut: overall healthScoreV2/healthLabel forced NULL for korg (Linux Kernel, IN-1244)
         -- since its per-category scores are populated but the overall rollup isn't meaningful for it.
-        -- revisit: generalize once the project-level rollup's null-vs-populated-categories mismatch is root-caused.
+        -- revisit: generalize once the project-level rollup's null-vs-populated-categories mismatch
+        -- is root-caused.
         if(base.slug = 'korg', NULL, toUInt8(round(hv2.healthScoreV2))) AS healthScoreV2,
         multiIf(
             base.slug = 'korg',

--- a/services/libs/tinybird/pipes/project_insights_copy.pipe
+++ b/services/libs/tinybird/pipes/project_insights_copy.pipe
@@ -181,8 +181,13 @@ SQL >
         pm.forksPrevious365Days AS forksPrevious365Days,
         pm.activeContributorsPrevious365Days AS activeContributorsPrevious365Days,
         pm.activeOrganizationsPrevious365Days AS activeOrganizationsPrevious365Days,
-        toUInt8(round(hv2.healthScoreV2)) AS healthScoreV2,
+        -- shortcut: overall healthScoreV2/healthLabel forced NULL for korg (Linux Kernel, IN-1244)
+        -- since its per-category scores are populated but the overall rollup isn't meaningful for it.
+        -- revisit: generalize once the project-level rollup's null-vs-populated-categories mismatch is root-caused.
+        if(base.slug = 'korg', NULL, toUInt8(round(hv2.healthScoreV2))) AS healthScoreV2,
         multiIf(
+            base.slug = 'korg',
+            NULL,
             hv2.healthScoreV2 IS NULL,
             NULL,
             hv2.healthScoreV2 >= 85,

--- a/services/libs/tinybird/pipes/project_insights_impact_breakdown_copy.pipe
+++ b/services/libs/tinybird/pipes/project_insights_impact_breakdown_copy.pipe
@@ -218,7 +218,9 @@ SQL >
         ) AS centralityBand,
         sonatypePopularityScore,
         if(
-            sonatypePopularityScore IS NULL, NULL, round(100.0 * sonatypePopularityScoreRank / sonatypePopularityScoreTotalRanked, 2)
+            sonatypePopularityScore IS NULL,
+            NULL,
+            round(100.0 * sonatypePopularityScoreRank / sonatypePopularityScoreTotalRanked, 2)
         ) AS sonatypePopularityScoreTopPct,
         if(
             sonatypePopularityScore IS NULL,


### PR DESCRIPTION
## Summary
- The Linux Kernel project (`korg`) has populated per-category health scores but an overall rollup that isn't meaningful for it, causing inconsistent null/non-null behavior across consumers (Insights frontend, public API e.g. CNCF, Snowflake sink).
- Adds a scoped Tinybird exception in `project_insights_copy.pipe` forcing `healthScoreV2`/`healthLabel` to `NULL` for `korg` at the data layer, so every consumer sees the same null total consistently instead of each needing to special-case it (per Joana's review comment on #2122).
- Category-level scores (`maintainerHealthScoreV2`, `securitySupplyChainScoreV2`, `developmentActivityScoreV2`) remain populated for `korg` — only the composite total/label is suppressed.
- This is an explicit, scoped shortcut (marked in code) for IN-1244 rather than a fix to the general project-level rollup logic; see the `revisit:` comment in the diff.

## Test plan
- [ ] Deploy pipe to Tinybird production, rerun copy pipe job
- [ ] Verify `korg` project row in `project_insights` endpoint returns `healthScoreV2: null`, `healthLabel: null`, with category scores still populated
- [ ] Verify Insights frontend (already-merged health-breakdown-section.vue gating) renders korg's health section correctly with total unavailable but categories shown