### PR TITLE
chore: use median instead of mean for project health score v2 rollup (IN-1246)

### DIFF
--- a/services/libs/tinybird/datasources/project_insights_copy_ds.datasource
+++ b/services/libs/tinybird/datasources/project_insights_copy_ds.datasource
@@ -32,7 +32,7 @@ DESCRIPTION >
     - `activeContributorsPrevious365Days` column is the unique count of active contributors in the previous 365 days (365-730 days ago).
     - `activeOrganizationsPrevious365Days` column is the unique count of active organizations in the previous 365 days (365-730 days ago).
     - `status` column is the current status of the project (e.g., 'active', 'archived').
-    - `healthScoreV2` column is the Akrites-methodology composite health score (0-100), median (`quantileExact(0.5)`) of repo scores across the project's enabled, non-excluded repos. Distinct from the legacy `healthScore` column (community/contributor-based); null when the project has no linked repo data.
+    - `healthScoreV2` column is the Akrites-methodology composite health score (0-100), median (`quantileExact(0.5)`) of repo scores across the project's enabled, non-excluded repos. Distinct from the legacy `healthScore` column (community/contributor-based); null when the project has no enabled, non-excluded repos or when all such repos have null scores (insufficient coverage data).
     - `healthLabel` column buckets `healthScoreV2`: 'excellent' (85+), 'healthy' (70-84), 'fair' (50-69), 'concerning' (30-49), 'critical' (<30). Lowercase, matches `ossPackages_enriched_ds.healthLabel` convention.
     - `lifecycleLabel` column is the project's aggregated maintenance state across its packages, using best-state-wins precedence (active > stable > declining > abandoned > archived) over `ossPackages_enriched_ds.lifecycleLabel`.
     - `impactScore` column is the average Osprey criticality `impact` (0-100) across the project's packages. Null when the project has no linked package data.

--- a/services/libs/tinybird/datasources/project_insights_copy_ds.datasource
+++ b/services/libs/tinybird/datasources/project_insights_copy_ds.datasource
@@ -32,14 +32,14 @@ DESCRIPTION >
     - `activeContributorsPrevious365Days` column is the unique count of active contributors in the previous 365 days (365-730 days ago).
     - `activeOrganizationsPrevious365Days` column is the unique count of active organizations in the previous 365 days (365-730 days ago).
     - `status` column is the current status of the project (e.g., 'active', 'archived').
-    - `healthScoreV2` column is the Akrites-methodology composite health score (0-100), median (`quantileExact(0.5)`) of repo scores across the project's enabled, non-excluded repos. Distinct from the legacy `healthScore` column (community/contributor-based); null when the project has no enabled, non-excluded repos or when all such repos have null scores (insufficient coverage data).
+    - `healthScoreV2` column is the Akrites-methodology composite health score (0-100). For project records (`type='project'`): median (`quantileExact(0.5)`) of per-repo scores across the project's enabled, non-excluded repos; null when no such repos exist or all have null scores. For repo records (`type='repo'`): per-repo score passed through from `health_score_v2_repo_copy_ds`. Distinct from the legacy `healthScore` column (community/contributor-based).
     - `healthLabel` column buckets `healthScoreV2`: 'excellent' (85+), 'healthy' (70-84), 'fair' (50-69), 'concerning' (30-49), 'critical' (<30). Lowercase, matches `ossPackages_enriched_ds.healthLabel` convention.
     - `lifecycleLabel` column is the project's aggregated maintenance state across its packages, using best-state-wins precedence (active > stable > declining > abandoned > archived) over `ossPackages_enriched_ds.lifecycleLabel`.
     - `impactScore` column is the average Osprey criticality `impact` (0-100) across the project's packages. Null when the project has no linked package data.
     - `impactLabel` column buckets `impactScore`: 'foundational' (85-100), 'major' (60-84), 'moderate' (30-59), 'minor' (0-29). Null when `impactScore` is null.
-    - `maintainerHealthScoreV2` column is the project-level rollup (0-40) of `health_score_v2_repo_copy_ds.maintainerHealthScoreV2` — median across the project's enabled, non-excluded repos, same convention as `healthScoreV2`. Null when no repo has a value.
-    - `securitySupplyChainScoreV2` column is the project-level rollup (0-35) of `health_score_v2_repo_copy_ds.securitySupplyChainScoreV2` — median across the project's enabled, non-excluded repos. Null when no repo has a value.
-    - `developmentActivityScoreV2` column is the project-level rollup (0-25) of `health_score_v2_repo_copy_ds.developmentActivityScoreV2` — median across the project's enabled, non-excluded repos. Null when no repo has a value.
+    - `maintainerHealthScoreV2` column (0-40): for project records, median (`quantileExact(0.5)`) of per-repo values across the project's enabled, non-excluded repos; for repo records, per-repo value from `health_score_v2_repo_copy_ds`. Null when no value is available.
+    - `securitySupplyChainScoreV2` column (0-35): same convention as `maintainerHealthScoreV2`. Null when no value is available.
+    - `developmentActivityScoreV2` column (0-25): same convention as `maintainerHealthScoreV2`. Null when no value is available.
 
 TAGS "Project insights", "Metrics"
 

--- a/services/libs/tinybird/datasources/project_insights_copy_ds.datasource
+++ b/services/libs/tinybird/datasources/project_insights_copy_ds.datasource
@@ -32,14 +32,14 @@ DESCRIPTION >
     - `activeContributorsPrevious365Days` column is the unique count of active contributors in the previous 365 days (365-730 days ago).
     - `activeOrganizationsPrevious365Days` column is the unique count of active organizations in the previous 365 days (365-730 days ago).
     - `status` column is the current status of the project (e.g., 'active', 'archived').
-    - `healthScoreV2` column is the Akrites-methodology composite health score (0-100), averaged from `ossPackages_enriched_ds.healthScore` across the project's linked packages. Distinct from the legacy `healthScore` column (community/contributor-based); null when the project has no linked package data.
+    - `healthScoreV2` column is the Akrites-methodology composite health score (0-100), median (`quantileExact(0.5)`) of repo scores across the project's enabled, non-excluded repos. Distinct from the legacy `healthScore` column (community/contributor-based); null when the project has no linked repo data.
     - `healthLabel` column buckets `healthScoreV2`: 'excellent' (85+), 'healthy' (70-84), 'fair' (50-69), 'concerning' (30-49), 'critical' (<30). Lowercase, matches `ossPackages_enriched_ds.healthLabel` convention.
     - `lifecycleLabel` column is the project's aggregated maintenance state across its packages, using best-state-wins precedence (active > stable > declining > abandoned > archived) over `ossPackages_enriched_ds.lifecycleLabel`.
     - `impactScore` column is the average Osprey criticality `impact` (0-100) across the project's packages. Null when the project has no linked package data.
     - `impactLabel` column buckets `impactScore`: 'foundational' (85-100), 'major' (60-84), 'moderate' (30-59), 'minor' (0-29). Null when `impactScore` is null.
-    - `maintainerHealthScoreV2` column is the project-level rollup (0-40) of `health_score_v2_repo_copy_ds.maintainerHealthScoreV2` — mean across the project's enabled, non-excluded repos, same convention as `healthScoreV2`. Null when no repo has a value.
-    - `securitySupplyChainScoreV2` column is the project-level rollup (0-35) of `health_score_v2_repo_copy_ds.securitySupplyChainScoreV2` — mean across the project's enabled, non-excluded repos. Null when no repo has a value.
-    - `developmentActivityScoreV2` column is the project-level rollup (0-25) of `health_score_v2_repo_copy_ds.developmentActivityScoreV2` — mean across the project's enabled, non-excluded repos. Null when no repo has a value.
+    - `maintainerHealthScoreV2` column is the project-level rollup (0-40) of `health_score_v2_repo_copy_ds.maintainerHealthScoreV2` — median across the project's enabled, non-excluded repos, same convention as `healthScoreV2`. Null when no repo has a value.
+    - `securitySupplyChainScoreV2` column is the project-level rollup (0-35) of `health_score_v2_repo_copy_ds.securitySupplyChainScoreV2` — median across the project's enabled, non-excluded repos. Null when no repo has a value.
+    - `developmentActivityScoreV2` column is the project-level rollup (0-25) of `health_score_v2_repo_copy_ds.developmentActivityScoreV2` — median across the project's enabled, non-excluded repos. Null when no repo has a value.
 
 TAGS "Project insights", "Metrics"
 

--- a/services/libs/tinybird/pipes/project_insights.pipe
+++ b/services/libs/tinybird/pipes/project_insights.pipe
@@ -13,7 +13,7 @@ DESCRIPTION >
     - `page`: Optional integer for pagination offset calculation, defaults to 0
     - Response: Project records with all insights metrics including achievements as array of (leaderboardType, rank, totalCount) tuples
     - `healthScoreV2`, `healthLabel`, `lifecycleLabel`, `impactScore`, `impactLabel` are the Akrites-methodology fields (see `project_insights_copy_ds` for band definitions); may be null when the project has no linked package data. `healthScoreV2` is distinct from the legacy `healthScore` field.
-    - `maintainerHealthScoreV2` (0-40), `securitySupplyChainScoreV2` (0-35), `developmentActivityScoreV2` (0-25) are the project-level rollup of the Health Score v2 category breakdown (IN-1212) — the three categories that sum to `healthScoreV2`. Null when no repo in the project has a value for that category.
+    - `maintainerHealthScoreV2` (0-40), `securitySupplyChainScoreV2` (0-35), `developmentActivityScoreV2` (0-25) are the project-level rollup of the Health Score v2 category breakdown (IN-1212) — independent medians (`quantileExact(0.5)`) over the same enabled, non-excluded repo set as `healthScoreV2`. At repo level the three categories sum to `healthScoreV2`; at project level they are independent medians and do not necessarily sum to `healthScoreV2` for multi-repo projects. Null when no repo in the project has a value for that category.
 
 TAGS "Insights, Widget", "Project"
 

--- a/services/libs/tinybird/pipes/project_insights.pipe
+++ b/services/libs/tinybird/pipes/project_insights.pipe
@@ -13,7 +13,7 @@ DESCRIPTION >
     - `page`: Optional integer for pagination offset calculation, defaults to 0
     - Response: Project records with all insights metrics including achievements as array of (leaderboardType, rank, totalCount) tuples
     - `healthScoreV2`, `healthLabel`, `lifecycleLabel`, `impactScore`, `impactLabel` are the Akrites-methodology fields (see `project_insights_copy_ds` for band definitions); may be null when the project has no linked package data. `healthScoreV2` is distinct from the legacy `healthScore` field.
-    - `maintainerHealthScoreV2` (0-40), `securitySupplyChainScoreV2` (0-35), `developmentActivityScoreV2` (0-25) are the project-level rollup of the Health Score v2 category breakdown (IN-1212) — independent medians (`quantileExact(0.5)`) over the same enabled, non-excluded repo set as `healthScoreV2`. At repo level the three categories sum to `healthScoreV2`; at project level they are independent medians and do not necessarily sum to `healthScoreV2` for multi-repo projects. Null when no repo in the project has a value for that category.
+    - `maintainerHealthScoreV2` (0-40), `securitySupplyChainScoreV2` (0-35), `developmentActivityScoreV2` (0-25) are the project-level rollup of the Health Score v2 category breakdown (IN-1212) — independent medians (`quantileExact(0.5)`) over the same enabled, non-excluded repo set as `healthScoreV2`; they do not necessarily sum to `healthScoreV2`. Null when no repo in the project has a value for that category.
 
 TAGS "Insights, Widget", "Project"
 

--- a/services/libs/tinybird/pipes/project_insights_copy.pipe
+++ b/services/libs/tinybird/pipes/project_insights_copy.pipe
@@ -121,7 +121,8 @@ DESCRIPTION >
 SQL >
     SELECT
         rep.insightsProjectId AS insightsProjectId,
-        quantileExact(0.5)(hv2.healthScoreV2) AS healthScoreV2,
+        quantileExact(0.5)
+        (hv2.healthScoreV2) AS healthScoreV2,
         if(
             empty(groupArray(hv2.lifecycleLabelV2)),
             NULL,
@@ -138,9 +139,12 @@ SQL >
             )
         ) AS lifecycleLabelV2,
         maxOrNull(hv2.impactScore) AS impactScoreRaw,
-        quantileExact(0.5)(hv2.maintainerHealthScoreV2) AS maintainerHealthScoreV2,
-        quantileExact(0.5)(hv2.securitySupplyChainScoreV2) AS securitySupplyChainScoreV2,
-        quantileExact(0.5)(hv2.developmentActivityScoreV2) AS developmentActivityScoreV2
+        quantileExact(0.5)
+        (hv2.maintainerHealthScoreV2) AS maintainerHealthScoreV2,
+        quantileExact(0.5)
+        (hv2.securitySupplyChainScoreV2) AS securitySupplyChainScoreV2,
+        quantileExact(0.5)
+        (hv2.developmentActivityScoreV2) AS developmentActivityScoreV2
     FROM repositories rep FINAL
     INNER JOIN health_score_v2_repo_copy_ds hv2 ON hv2.repoUrl = rep.url
     WHERE rep.insightsProjectId != '' AND rep.enabled = true AND rep.excluded = false

--- a/services/libs/tinybird/pipes/project_insights_copy.pipe
+++ b/services/libs/tinybird/pipes/project_insights_copy.pipe
@@ -90,7 +90,7 @@ DESCRIPTION >
     Lifecycle, Health Score v2, and Impact Score all rolled up to project level from the pre-computed
     per-repo values in health_score_v2_repo_copy_ds (materialized by health_score_v2.pipe — the
     expensive per-signal joins run there as their own copy job, not inline here). Per spec section 5/6:
-    - healthScoreV2: straight mean across the project's enabled, non-excluded repos.
+    - healthScoreV2: exact median (`quantileExact(0.5)`) across the project's enabled, non-excluded repos.
     - lifecycleLabelV2: best-state-wins (active > stable > declining > inert > abandoned > archived), with
     NULL (no usable signal, see health_score_v2_lifecycle.pipe) as the most-cautious outcome.
     `groupArray` silently drops NULL entries, so a project with at least one repo in a real state
@@ -112,15 +112,16 @@ DESCRIPTION >
     published packages) — matches the spec's "MAX(packages.impact) over packages published by any
     repo in the project," since max-of-maxes = max-over-all.
     - maintainerHealthScoreV2 / securitySupplyChainScoreV2 / developmentActivityScoreV2 (IN-1212): same
-    straight-mean rollup as healthScoreV2, over the same repo set — kept consistent since healthScoreV2
+    exact-median rollup as healthScoreV2, over the same repo set — kept consistent since healthScoreV2
     is itself defined as the sum of these three categories at repo level (see
-    health_score_v2_repo_copy_ds). `avg()` (not avgOrNull) matches the healthScoreV2 idiom above and
-    already returns NULL, not 0/NaN, when every repo is NULL for a category (confirmed live).
+    health_score_v2_repo_copy_ds). `quantileExact(0.5)` (not quantile/median, which uses reservoir
+    sampling) already returns NULL, not 0/NaN, when every repo is NULL for a category (confirmed live);
+    deterministic output required to reproduce v1↔v2 divergence analysis and acceptance-criteria targets.
 
 SQL >
     SELECT
         rep.insightsProjectId AS insightsProjectId,
-        avg(hv2.healthScoreV2) AS healthScoreV2,
+        quantileExact(0.5)(hv2.healthScoreV2) AS healthScoreV2,
         if(
             empty(groupArray(hv2.lifecycleLabelV2)),
             NULL,
@@ -137,9 +138,9 @@ SQL >
             )
         ) AS lifecycleLabelV2,
         maxOrNull(hv2.impactScore) AS impactScoreRaw,
-        avg(hv2.maintainerHealthScoreV2) AS maintainerHealthScoreV2,
-        avg(hv2.securitySupplyChainScoreV2) AS securitySupplyChainScoreV2,
-        avg(hv2.developmentActivityScoreV2) AS developmentActivityScoreV2
+        quantileExact(0.5)(hv2.maintainerHealthScoreV2) AS maintainerHealthScoreV2,
+        quantileExact(0.5)(hv2.securitySupplyChainScoreV2) AS securitySupplyChainScoreV2,
+        quantileExact(0.5)(hv2.developmentActivityScoreV2) AS developmentActivityScoreV2
     FROM repositories rep FINAL
     INNER JOIN health_score_v2_repo_copy_ds hv2 ON hv2.repoUrl = rep.url
     WHERE rep.insightsProjectId != '' AND rep.enabled = true AND rep.excluded = false

--- a/services/libs/tinybird/pipes/project_repo_insights.pipe
+++ b/services/libs/tinybird/pipes/project_repo_insights.pipe
@@ -12,7 +12,7 @@ DESCRIPTION >
     - `page`: Optional integer for pagination offset calculation, defaults to 0
     - Response: Project and repository records with insights metrics
     - `healthScoreV2`, `healthLabel`, `lifecycleLabel`, `impactScore`, `impactLabel` are the Akrites-methodology fields (see `project_insights_copy_ds` for band definitions); may be null when the record has no linked package data. `healthScoreV2` is distinct from the legacy `healthScore` field.
-    - `maintainerHealthScoreV2` (0-40), `securitySupplyChainScoreV2` (0-35), `developmentActivityScoreV2` (0-25) are the rollup of the Health Score v2 category breakdown (IN-1212) — independent medians (`quantileExact(0.5)`) over the same enabled, non-excluded repo set as `healthScoreV2`. At repo level the three categories sum to `healthScoreV2`; at project level they are independent medians and do not necessarily sum to `healthScoreV2` for multi-repo projects. Null when the record has no value for that category.
+    - `maintainerHealthScoreV2` (0-40), `securitySupplyChainScoreV2` (0-35), `developmentActivityScoreV2` (0-25) are the Health Score v2 category breakdown (IN-1212). For project records: independent medians (`quantileExact(0.5)`) over the project's enabled, non-excluded repos — they do not necessarily sum to `healthScoreV2`. For repo records: per-repo values passed through from `health_score_v2_repo_copy_ds`; they sum to `healthScoreV2` only when all three categories are available (partial coverage rescales). Null when the record has no value for that category.
 
 TAGS "Insights, Widget", "Project", "Repository"
 

--- a/services/libs/tinybird/pipes/project_repo_insights.pipe
+++ b/services/libs/tinybird/pipes/project_repo_insights.pipe
@@ -12,7 +12,7 @@ DESCRIPTION >
     - `page`: Optional integer for pagination offset calculation, defaults to 0
     - Response: Project and repository records with insights metrics
     - `healthScoreV2`, `healthLabel`, `lifecycleLabel`, `impactScore`, `impactLabel` are the Akrites-methodology fields (see `project_insights_copy_ds` for band definitions); may be null when the record has no linked package data. `healthScoreV2` is distinct from the legacy `healthScore` field.
-    - `maintainerHealthScoreV2` (0-40), `securitySupplyChainScoreV2` (0-35), `developmentActivityScoreV2` (0-25) are the rollup of the Health Score v2 category breakdown (IN-1212) — the three categories that sum to `healthScoreV2`. Null when the record has no value for that category.
+    - `maintainerHealthScoreV2` (0-40), `securitySupplyChainScoreV2` (0-35), `developmentActivityScoreV2` (0-25) are the rollup of the Health Score v2 category breakdown (IN-1212) — independent medians (`quantileExact(0.5)`) over the same enabled, non-excluded repo set as `healthScoreV2`. At repo level the three categories sum to `healthScoreV2`; at project level they are independent medians and do not necessarily sum to `healthScoreV2` for multi-repo projects. Null when the record has no value for that category.
 
 TAGS "Insights, Widget", "Project", "Repository"
 


### PR DESCRIPTION
## Summary

- Swaps `avg()` for `quantileExact(0.5)` in `project_insights_copy_health_v2_project` (4 aggregations: `healthScoreV2`, `maintainerHealthScoreV2`, `securitySupplyChainScoreV2`, `developmentActivityScoreV2`)
- Multi-repo LF projects were penalised by a long tail of low-activity repos dragging down the plain mean; median removes that bias
- Single-repo projects are unaffected (median of one value equals the mean)
- `health_score_v2_sink.pipe` inherits the change automatically — it is a pass-through from `project_insights_copy_ds`, no re-aggregation
- Datasource column docs updated to reflect the new rollup method; no schema change

Jira: https://linuxfoundation.atlassian.net/browse/IN-1246