### PR TITLE
fix: replace linear OpenSSF Scorecard map with banded mapping (IN-1247)

### DIFF
--- a/services/libs/tinybird/pipes/health_score_v2_security.pipe
+++ b/services/libs/tinybird/pipes/health_score_v2_security.pipe
@@ -13,6 +13,9 @@ DESCRIPTION >
     (NULL) when covered weight is <40% of 35.
     - Split out of health_score_v2.pipe into its own copy pipe (2026-07-22) — see
     health_score_v2_maintainer.pipe description for why.
+    - Scorecard banded mapping (2026-08-27, IN-1247): raw ≥ 7 → 7 pts, ≥ 5.5 → 5, ≥ 4 → 4,
+    ≥ 2.5 → 2, else 0. Replaces the linear round(min(raw,10)×0.7) which required raw ≥ 9.3 for
+    full points (only 0.33% of repos), calibrated to real distribution (median ≈ 4, p99 ≈ 7.9).
 
 NODE health_score_v2_security_calc
 SQL >
@@ -94,7 +97,17 @@ SQL >
                         vc.openHighs AS openHighs,
                         vc.openModerates AS openModerates,
                         toUInt8(
-                            round(least(toFloat64OrZero(rd.scorecardScore), 10) * 0.7)
+                            multiIf(
+                                toFloat64OrZero(rd.scorecardScore) >= 7,
+                                7,
+                                toFloat64OrZero(rd.scorecardScore) >= 5.5,
+                                5,
+                                toFloat64OrZero(rd.scorecardScore) >= 4,
+                                4,
+                                toFloat64OrZero(rd.scorecardScore) >= 2.5,
+                                2,
+                                0
+                            )
                         ) AS scorecardScorePts,
                         (rd.scorecardLastRunAt IS NOT NULL) AS scorecardAvailable,
                         rd.scorecardScore AS scorecardScore,


### PR DESCRIPTION
## Summary

- Replaces `round(min(raw, 10) × 0.7)` with a banded mapping calibrated to the real raw score distribution (median ≈ 4, p99 ≈ 7.9)
- Bands: raw ≥ 7 → 7 pts, ≥ 5.5 → 5, ≥ 4 → 4, ≥ 2.5 → 2, else 0
- 7-point weight and `scorecardAvailable` gate unchanged; no schema changes downstream

**Effect:** repos reaching full Scorecard points 41 → ~889; mean security score among scored repos 21.1 → 21.5. Project-level impact grows as scan coverage (~25% of LF repos) improves.

**Out of scope:** legacy `ossPackages_enriched.pipe` v1 linear mapping — left for v1 deprecation; public-API `× 10` scale mappings in `openapi.yaml` files (different scale, unrelated).

**Post-merge:** replay `health_score_v2_security_ds`, `health_score_v2_signal_detail_ds`, and `project_insights_health_breakdown_ds`.

Closes IN-1247