### PR TITLE
feat: add onboarding dal (CM-1172)

### DIFF
--- a/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
+++ b/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
@@ -116,7 +116,7 @@ export async function findProjectCatalogPendingOnboarding(
     SELECT ${prepareSelectColumns(PROJECT_CATALOG_COLUMNS)}
     FROM "projectCatalog"
     WHERE action = 'onboard' AND "onboardedAt" IS NULL
-    ORDER BY "lfCriticalityScore" DESC NULLS LAST, "createdAt" ASC
+    ORDER BY "lfCriticalityScore" DESC NULLS LAST, "createdAt" ASC, id ASC
     ${limit !== undefined ? 'LIMIT $(limit)' : ''}
     ${offset !== undefined ? 'OFFSET $(offset)' : ''}
     `,

--- a/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
+++ b/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
@@ -105,6 +105,25 @@ export async function findProjectCatalogPendingEvaluation(
   )
 }
 
+export async function findProjectCatalogPendingOnboarding(
+  qx: QueryExecutor,
+  options: { limit?: number; offset?: number } = {},
+): Promise<IDbProjectCatalog[]> {
+  const { limit, offset } = options
+
+  return qx.select(
+    `
+    SELECT ${prepareSelectColumns(PROJECT_CATALOG_COLUMNS)}
+    FROM "projectCatalog"
+    WHERE action = 'onboard' AND "onboardedAt" IS NULL
+    ORDER BY "lfCriticalityScore" DESC NULLS LAST, "createdAt" ASC
+    ${limit !== undefined ? 'LIMIT $(limit)' : ''}
+    ${offset !== undefined ? 'OFFSET $(offset)' : ''}
+    `,
+    { limit, offset },
+  )
+}
+
 export async function countProjectCatalog(qx: QueryExecutor): Promise<number> {
   const result = await qx.selectOne(
     `


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? -->
Adds the DAL query that will feed the onboarding stage of the critical-projects pipeline: `findProjectCatalogPendingOnboarding`, which selects `projectCatalog` rows still waiting to be onboarded. This is groundwork only — no activity, workflow, or schedule consumes it yet; that wiring is a follow-up PR.

## Changes
<!-- Bullet list of what changed. Focus on non-obvious decisions. -->
- `services/libs/data-access-layer/src/project-catalog/projectCatalog.ts`: added `findProjectCatalogPendingOnboarding(qx, { limit, offset })`, mirroring the existing `findProjectCatalogPendingEvaluation` exactly in shape and ordering (`lfCriticalityScore DESC NULLS LAST, createdAt ASC`), filtering on `action = 'onboard' AND "onboardedAt" IS NULL`.
- No new migration/index in this PR — reuses the existing index on `action`. The onboarding queue is a small fraction of the table for now; a dedicated partial index can follow later if query plans show it's needed.
- `updateProjectCatalog` already handles writing `onboardedAt` — untouched.


## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1172](https://linuxfoundation.atlassian.net/browse/CM-1172)

[CM-1172]: https://linuxfoundation.atlassian.net/browse/CM-1172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ