### PR TITLE
fix: return 404 when merging a member that no longer exists

### DIFF
--- a/services/apps/members_enrichment_worker/src/activities/member.ts
+++ b/services/apps/members_enrichment_worker/src/activities/member.ts
@@ -1,3 +1,4 @@
+import { Error404 } from '@crowd/common'
 import { CommonMemberService } from '@crowd/common_services'
 import {
   MemberField,
@@ -136,6 +137,14 @@ export async function mergeMembers(
   try {
     await memberService.merge(primaryMemberId, secondaryMemberId)
   } catch (error) {
+    if (error instanceof Error404) {
+      svc.log.info(
+        { primaryMemberId, secondaryMemberId },
+        'Skipping merge, member no longer exists',
+      )
+      return
+    }
+
     svc.log.error({ err: error }, 'Failed to merge members')
     throw error
   }

--- a/services/apps/merge_suggestions_worker/src/activities/common.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/common.ts
@@ -3,7 +3,7 @@ import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedroc
 import axios from 'axios'
 import { performance } from 'perf_hooks'
 
-import { IS_LLM_ENABLED } from '@crowd/common'
+import { Error404, IS_LLM_ENABLED } from '@crowd/common'
 import { CommonMemberService } from '@crowd/common_services'
 import { pgpQx } from '@crowd/data-access-layer'
 import { ITenant } from '@crowd/data-access-layer/src/old/apps/merge_suggestions_worker//types'
@@ -110,6 +110,14 @@ export async function mergeMembers(
   try {
     await memberService.merge(primaryMemberId, secondaryMemberId)
   } catch (error) {
+    if (error instanceof Error404) {
+      svc.log.info(
+        { primaryMemberId, secondaryMemberId },
+        'Skipping merge, member no longer exists',
+      )
+      return
+    }
+
     svc.log.error({ err: error }, 'Failed to merge members')
     throw error
   }

--- a/services/apps/script_executor_worker/src/activities/common.ts
+++ b/services/apps/script_executor_worker/src/activities/common.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 
+import { Error404 } from '@crowd/common'
 import { CommonMemberService, signalMemberUpdate } from '@crowd/common_services'
 import { pgpQx } from '@crowd/data-access-layer'
 import {
@@ -22,6 +23,14 @@ export async function mergeMembers(
   try {
     await memberService.merge(primaryMemberId, secondaryMemberId)
   } catch (error) {
+    if (error instanceof Error404) {
+      svc.log.info(
+        { primaryMemberId, secondaryMemberId },
+        'Skipping merge, member no longer exists',
+      )
+      return
+    }
+
     svc.log.error({ err: error }, 'Failed to merge members')
     throw error
   }

--- a/services/libs/common_services/src/services/common.member.service.ts
+++ b/services/libs/common_services/src/services/common.member.service.ts
@@ -10,6 +10,7 @@ import {
 } from '@crowd/audit-logs'
 import {
   DEFAULT_TENANT_ID,
+  Error404,
   Error409,
   calculateReach,
   getEarliestValidDate,
@@ -358,6 +359,10 @@ export class CommonMemberService extends LoggerBase {
           const original = await this.getMemberById(originalId)
           const toMerge = await this.getMemberById(toMergeId)
 
+          if (!original || !toMerge) {
+            throw new Error404(options?.language)
+          }
+
           captureOldState({
             primary: original,
             secondary: toMerge,
@@ -486,6 +491,10 @@ export class CommonMemberService extends LoggerBase {
         return { status: 409, mergedId: originalId }
       }
 
+      if (err instanceof Error404) {
+        throw err
+      }
+
       this.log.error(err, 'Error while merging members!', { originalId, toMergeId })
 
       await setMergeAction(this.qx, MergeActionType.MEMBER, originalId, toMergeId, {
@@ -509,6 +518,10 @@ export class CommonMemberService extends LoggerBase {
       MemberField.MANUALLY_CREATED,
       MemberField.MANUALLY_CHANGED_FIELDS,
     ])
+
+    if (!member) {
+      return null
+    }
 
     const affiliations = await findMemberAffiliations(this.qx, memberId)
 


### PR DESCRIPTION
## Summary

Merge suggestions can still send a merge against a profile that was just merged away. After a successful merge we hard-delete the extra member. If the UI still has that id (next suggestion already on screen, or a retry), we try to move identities onto a member that no longer exists.

Postgres then fails with `memberIdentities_memberId_fkey` (`insert or update on table "memberIdentities" violates foreign key constraint`). The API returns 500 and Slack reports `API Error 500: PUT /member/:id/merge` / `SequelizeForeignKeyConstraintError`.

That is a stale request, not bad identity data. The leftover profile should stay put; a new suggestion can pair it with whoever is still alive.

## Changes

- Return 404 if either member is gone, before any identity updates. The suggestions UI already treats 404 as “already merged or deleted” and loads the next pair.
- Treat that 404 as a skip in merge workers so Temporal does not retry the deleted id.