### PR TITLE
feat: add manual priority (CM-1138)

### DIFF
--- a/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
+++ b/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
@@ -117,7 +117,11 @@ export async function findProjectCatalogPendingOnboarding(
     SELECT ${prepareSelectColumns(PROJECT_CATALOG_COLUMNS)}
     FROM "projectCatalog"
     WHERE action = 'onboard' AND "onboardedAt" IS NULL
-    ORDER BY "lfCriticalityScore" DESC NULLS LAST, "createdAt" ASC, id ASC
+    ORDER BY
+      (source = 'manual') DESC NULLS LAST,
+      "lfCriticalityScore" DESC NULLS LAST,
+      "createdAt" ASC,
+      id ASC
     ${limit !== undefined ? 'LIMIT $(limit)' : ''}
     ${offset !== undefined ? 'OFFSET $(offset)' : ''}
     `,


### PR DESCRIPTION
## Summary

Gives `projectCatalog` rows with `source = 'manual'` top priority in the automatic onboarding pickup query, regardless of their `lfCriticalityScore`. This is groundwork for an upcoming API that will let manual entries be onboarded immediately instead of waiting behind auto-discovered projects that happen to have a higher/non-null criticality score.

## Changes

- `services/libs/data-access-layer/src/project-catalog/projectCatalog.ts`: `findProjectCatalogPendingOnboarding` now orders by `(source = 'manual') DESC NULLS LAST` before `lfCriticalityScore DESC NULLS LAST, createdAt ASC, id ASC`.
- `NULLS LAST` on the new sort key is required: Postgres's default `DESC` ordering puts `NULL` first, and `source` is nullable (defaults to `null` on every insert path when not supplied) — without it, rows with no `source` would jump ahead of both manual and non-manual entries.
- No `source = 'manual'` writer exists yet anywhere in the codebase — this only changes ordering for when that write path is added.
- No index change: the prior `ORDER BY` was already unsupported by any composite/filtered index (only single-column indexes exist on `lfCriticalityScore`, `source`, `action`), so this doesn't regress an existing index-order optimization — Postgres was already sorting in memory.


## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1138](https://linuxfoundation.atlassian.net/browse/CM-1138)

[CM-1138]: https://linuxfoundation.atlassian.net/browse/CM-1138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ