### PR TITLE
fix: use healthScoreV2 in collection avgHealthScore aggregation (IN-1257)

### DIFF
--- a/services/libs/tinybird/pipes/collection_insights_aggregate_projects_copy_pipe.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_projects_copy_pipe.pipe
@@ -12,10 +12,8 @@ NODE collection_insights_aggregate_projects_aggregated
 DESCRIPTION >
     Aggregates project counts and health scores per collection from insights_projects_populated_ds.
     Uses same "onboarded" definition as original logic: projects with organizationCount > 0 OR contributorCount > 0.
-    Must use healthScoreV2, not legacy healthScore, to agree with the member project card's
-    "Unavailable" state, which gates on healthScoreV2 IS NULL (IN-1257). A project with
-    healthScoreV2 IS NULL (e.g. korg, forced NULL per IN-1244) still counts in projectCount
-    but is excluded from avgHealthScore.
+    Averages healthScoreV2 (not legacy healthScore) to agree with the "Unavailable" state
+    shown elsewhere, which also gates on healthScoreV2 IS NULL (IN-1257).
 
 SQL >
     SELECT
@@ -42,7 +40,12 @@ SQL >
                 arrayJoin(p.collectionsSlugs) as collectionSlug
             FROM insights_projects_populated_ds p
             LEFT JOIN
-                (SELECT id, healthScoreV2 FROM project_insights_copy_ds WHERE type = 'project') pi
+                (
+                    SELECT id, any (healthScoreV2) as healthScoreV2
+                    FROM project_insights_copy_ds
+                    WHERE type = 'project'
+                    GROUP BY id
+                ) pi
                 ON pi.id = p.id
             WHERE p.enabled = 1
         )

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_projects_copy_pipe.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_projects_copy_pipe.pipe
@@ -2,8 +2,8 @@ DESCRIPTION >
     - Fast, small copy pipe for project-count and average health-score aggregation.
     - Scans ONLY insights_projects_populated_ds (no activity tables, no massive joins).
     - Produces projectCount and avgHealthScore per collection slug.
-    - Runs after all per-bucket contributor copy pipes have completed (all run in 2:05-2:50 window).
-    - Scheduled at 3:00 UTC to clear after all 10 bucket pipes finish, giving a 10-min safety margin.
+    - Runs after all per-bucket contributor copy pipes have completed (all run in 5:05-5:50 window).
+    - Scheduled at 6:00 UTC to clear after all 10 bucket pipes finish, giving a 10-min safety margin.
     - COPY_MODE replace: one row per collection per copy run (idempotent daily rebuild).
 
 TAGS "Insights, Widget", "Collection"
@@ -12,25 +12,39 @@ NODE collection_insights_aggregate_projects_aggregated
 DESCRIPTION >
     Aggregates project counts and health scores per collection from insights_projects_populated_ds.
     Uses same "onboarded" definition as original logic: projects with organizationCount > 0 OR contributorCount > 0.
+    Must use healthScoreV2, not legacy healthScore, to agree with the member project card's
+    "Unavailable" state, which gates on healthScoreV2 IS NULL (IN-1257). A project with
+    healthScoreV2 IS NULL (e.g. korg, forced NULL per IN-1244) still counts in projectCount
+    but is excluded from avgHealthScore.
 
 SQL >
     SELECT
         collectionSlug,
         count(distinct projectId) as projectCount,
         round(
-            avg(if(NOT ((organizationCount = 0) AND (contributorCount = 0)), healthScore, NULL))
+            avg(
+                if(
+                    NOT ((organizationCount = 0) AND (contributorCount = 0))
+                    AND healthScoreV2 IS NOT NULL,
+                    healthScoreV2,
+                    NULL
+                )
+            )
         ) as avgHealthScore,
         now() as updatedAt
     FROM
         (
             SELECT
-                id as projectId,
-                healthScore,
-                organizationCount,
-                contributorCount,
-                arrayJoin(collectionsSlugs) as collectionSlug
-            FROM insights_projects_populated_ds
-            WHERE enabled = 1
+                p.id as projectId,
+                pi.healthScoreV2 as healthScoreV2,
+                p.organizationCount,
+                p.contributorCount,
+                arrayJoin(p.collectionsSlugs) as collectionSlug
+            FROM insights_projects_populated_ds p
+            LEFT JOIN
+                (SELECT id, healthScoreV2 FROM project_insights_copy_ds WHERE type = 'project') pi
+                ON pi.id = p.id
+            WHERE p.enabled = 1
         )
     GROUP BY collectionSlug
 


### PR DESCRIPTION
## Summary

- Collection pages showed a numeric "Avg. Health" score in the header while a member project on the same page showed "Unavailable" — the copy pipe averaged legacy `healthScore`, but the frontend's "Unavailable" gate checks `healthScoreV2`. For the `korg` collection (Linux Kernel), `healthScoreV2` is intentionally null (IN-1244), so the two disagreed.
- `collection_insights_aggregate_projects_copy_pipe` now LEFT JOINs `project_insights_copy_ds` to pull `healthScoreV2`, and `avgHealthScore` averages that field (gated `IS NOT NULL`) instead of legacy `healthScore`. A project with null `healthScoreV2` still counts toward `projectCount`, matching the "onboarded" definition, but is excluded from the average.
- Also corrected a stale comment: the bucket pipes this copy pipe waits on run 5:05-5:50 UTC and it's scheduled at 6:00 UTC, not the 2:05-2:50/3:00 UTC the comment claimed.
- Scope: crowd.dev only. Insights already renders a null aggregate as "Unavailable" correctly, so no frontend change is needed there.
- This is a Tinybird pipe change, not an application code change — merging this PR does not fix production. `tb push` (staging then prod) must run via `crowd-tinybird-manager`, and the next scheduled COPY run (06:00 UTC) has to complete before collection pages show the corrected value.
- Cross-repo note for Insights/Collections owners: any collection containing a project with null `healthScoreV2` will now show a lower or null `avgHealthScore` than before, since those projects drop out of the average. That's the intended IN-1257 fix, not a regression.

## JIRA

IN-1257 — Linux Kernel collection shows avg health score value instead of Unavailable