### PR TITLE
feat: add onboarded status (CM-1138)

### DIFF
--- a/services/apps/automatic_onboarding_worker/src/activities/activities.ts
+++ b/services/apps/automatic_onboarding_worker/src/activities/activities.ts
@@ -61,6 +61,7 @@ export async function onboardAndUpdateProject(project: IDbProjectCatalog): Promi
   }
 
   await updateProjectCatalog(qx, project.id, {
+    action: 'onboarded',
     onboardedAt: new Date().toISOString(),
     onboardingError: null,
   })

--- a/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
+++ b/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
@@ -340,7 +340,7 @@ export async function upsertProjectCatalog(
       "repoName" = EXCLUDED."repoName",
       "source" = COALESCE(EXCLUDED."source", "projectCatalog"."source"),
       "action" = CASE
-        WHEN "projectCatalog"."action" IN ('onboard', 'skip', 'unsure', 'error') THEN "projectCatalog"."action"
+        WHEN "projectCatalog"."action" IN ('onboard', 'onboarded', 'skip', 'unsure', 'error') THEN "projectCatalog"."action"
         WHEN EXCLUDED.action = 'evaluate' THEN 'evaluate'
         ELSE "projectCatalog"."action"
       END,
@@ -413,7 +413,7 @@ export async function bulkUpsertProjectCatalog(
       "repoName" = EXCLUDED."repoName",
       "source" = COALESCE(EXCLUDED."source", "projectCatalog"."source"),
       "action" = CASE
-        WHEN "projectCatalog"."action" IN ('onboard', 'skip', 'unsure', 'error') THEN "projectCatalog"."action"
+        WHEN "projectCatalog"."action" IN ('onboard', 'onboarded', 'skip', 'unsure', 'error') THEN "projectCatalog"."action"
         WHEN EXCLUDED.action = 'evaluate' THEN 'evaluate'
         ELSE "projectCatalog"."action"
       END,

--- a/services/libs/data-access-layer/src/project-catalog/types.ts
+++ b/services/libs/data-access-layer/src/project-catalog/types.ts
@@ -1,4 +1,11 @@
-export type ProjectCatalogAction = 'auto' | 'evaluate' | 'onboard' | 'skip' | 'unsure' | 'error'
+export type ProjectCatalogAction =
+  | 'auto'
+  | 'evaluate'
+  | 'onboard'
+  | 'onboarded'
+  | 'skip'
+  | 'unsure'
+  | 'error'
 
 export interface IDbProjectCatalog {
   id: string


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? -->
<!-- Example: Adds batch processing for member enrichment to reduce API calls -->

Adds a dedicated terminal action value (`'onboarded'`) for successfully onboarded rows in `projectCatalog`, instead of reusing `'onboard'` for both "queued for onboarding" and "onboarding succeeded". Today the only signal distinguishing the two is `onboardedAt IS NOT NULL`, which is easy to miss when reading the table, writing a new query, or building a dashboard/monitor on top of it.

## Changes
<!-- Bullet list of what changed. Focus on non-obvious decisions. -->
- `services/libs/data-access-layer/src/project-catalog/types.ts`: added `'onboarded'` to the `ProjectCatalogAction` union.
- `services/apps/automatic_onboarding_worker/src/activities/activities.ts`: `onboardAndUpdateProject` now sets `action: 'onboarded'` alongside `onboardedAt` on successful onboarding, instead of leaving `action` untouched at `'onboard'`.
- `services/libs/data-access-layer/src/project-catalog/projectCatalog.ts`: added `'onboarded'` to the `ON CONFLICT` action-preserving `CASE` in both `upsertProjectCatalog` and `bulkUpsertProjectCatalog`, so a re-synced row that was already successfully onboarded doesn't get its action clobbered by discovery/evaluation upserts.
- `findProjectCatalogPendingOnboarding` and `markProjectCatalogOnboardingFailed` are unchanged: both already filter on `action = 'onboard' AND onboardedAt IS NULL`, which stays correct — a row is now moved out of `'onboard'` entirely on success, so the `onboardedAt` check becomes redundant-but-harmless rather than load-bearing.
- No DB migration needed: `action` is a plain `VARCHAR(16)` with no CHECK constraint or enum, and `'onboarded'` fits within the existing column width.


## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1138](https://linuxfoundation.atlassian.net/browse/CM-1138)

[CM-1138]: https://linuxfoundation.atlassian.net/browse/CM-1138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ