### PR TITLE
fix: make people list org display deterministic (CM-1391)

### DIFF
--- a/services/libs/data-access-layer/src/members/dataProcessor.ts
+++ b/services/libs/data-access-layer/src/members/dataProcessor.ts
@@ -14,6 +14,7 @@ interface MemberOrganization {
   dateEnd?: string
   affiliationOverride?: {
     isPrimaryWorkExperience?: boolean
+    allowAffiliation?: boolean
   }
 }
 
@@ -37,41 +38,61 @@ interface MemberSegmentData {
   }>
 }
 
+const OPEN_END = Date.parse('9999-12-31')
+
+const rangeMs = (org: MemberOrganization) => {
+  if (!org.dateStart) return 0
+  const end = org.dateEnd ? new Date(org.dateEnd).getTime() : OPEN_END
+  return end - new Date(org.dateStart).getTime()
+}
+
 export const sortActiveOrganizations = (
   activeOrgs: MemberOrganization[],
   organizationsInfo: OrganizationInfo[],
 ): MemberOrganization[] => {
-  return activeOrgs.sort((a, b) => {
+  return [...activeOrgs].sort((a, b) => {
     if (!a || !b) return 0
 
-    // First priority: isPrimaryWorkExperience
+    // First priority: allowed over blocked
+    const aAllowed = a.affiliationOverride?.allowAffiliation !== false
+    const bAllowed = b.affiliationOverride?.allowAffiliation !== false
+    if (aAllowed !== bAllowed) return aAllowed ? -1 : 1
+
+    // Second priority: isPrimaryWorkExperience
     const aPrimary = a.affiliationOverride?.isPrimaryWorkExperience === true
     const bPrimary = b.affiliationOverride?.isPrimaryWorkExperience === true
-
     if (aPrimary !== bPrimary) return aPrimary ? -1 : 1
 
-    // Second priority: has dateStart
+    // Third priority: has dateStart
     const aHasDate = !!a.dateStart
     const bHasDate = !!b.dateStart
-
     if (aHasDate !== bHasDate) return aHasDate ? -1 : 1
 
-    // Third priority: createdAt and alphabetical
-    if (!a.dateStart && !b.dateStart) {
-      const aOrgInfo = organizationsInfo.find((odn) => odn.id === a.organizationId)
-      const bOrgInfo = organizationsInfo.find((odn) => odn.id === b.organizationId)
-
-      const aCreatedAt = aOrgInfo?.createdAt ? new Date(aOrgInfo.createdAt).getTime() : 0
-      const bCreatedAt = bOrgInfo?.createdAt ? new Date(bOrgInfo.createdAt).getTime() : 0
-
-      if (aCreatedAt !== bCreatedAt) return bCreatedAt - aCreatedAt
-
-      const aName = (aOrgInfo?.displayName || '').toLowerCase()
-      const bName = (bOrgInfo?.displayName || '').toLowerCase()
-      return aName.localeCompare(bName)
+    // Fourth priority: longer date range, then id
+    if (aHasDate && bHasDate) {
+      const rangeDiff = rangeMs(b) - rangeMs(a)
+      if (rangeDiff !== 0) return rangeDiff
+      return a.id.localeCompare(b.id)
     }
 
-    return 0
+    // Undated: createdAt, then name, then id
+    const aOrgInfo = organizationsInfo.find((odn) => odn.id === a.organizationId)
+    const bOrgInfo = organizationsInfo.find((odn) => odn.id === b.organizationId)
+
+    const aCreatedAt = aOrgInfo?.createdAt ? new Date(aOrgInfo.createdAt).getTime() : 0
+    const bCreatedAt = bOrgInfo?.createdAt ? new Date(bOrgInfo.createdAt).getTime() : 0
+    if (aCreatedAt !== bCreatedAt) return bCreatedAt - aCreatedAt
+
+    const nameDiff = (aOrgInfo?.displayName || '').localeCompare(
+      bOrgInfo?.displayName || '',
+      undefined,
+      {
+        sensitivity: 'base',
+      },
+    )
+    if (nameDiff !== 0) return nameDiff
+
+    return a.id.localeCompare(b.id)
   })
 }
 

--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -189,18 +189,19 @@ export async function fetchManyMemberOrgs(
   qx: QueryExecutor,
   memberIds: string[],
 ): Promise<{ memberId: string; organizations: IMemberOrganization[] }[]> {
+  // Include affiliation override flags. Order by id so equal createdAt stays stable.
   return qx.select(
     `
       SELECT
         mo."memberId",
         JSONB_AGG(
           TO_JSONB(mo) || JSONB_BUILD_OBJECT(
-            'affiliationOverride', 
-            CASE WHEN moao."isPrimaryWorkExperience" IS NOT NULL 
-                 THEN JSONB_BUILD_OBJECT('isPrimaryWorkExperience', moao."isPrimaryWorkExperience")
-                 ELSE NULL 
-            END
-          ) ORDER BY mo."createdAt"
+            'affiliationOverride',
+            JSONB_BUILD_OBJECT(
+              'isPrimaryWorkExperience', COALESCE(moao."isPrimaryWorkExperience", false),
+              'allowAffiliation', COALESCE(moao."allowAffiliation", true)
+            )
+          ) ORDER BY mo."createdAt", mo.id
         ) AS "organizations"
       FROM "memberOrganizations" mo
       LEFT JOIN "memberOrganizationAffiliationOverrides" moao 


### PR DESCRIPTION
## Summary
- The people list could show a different current organization for the same person depending on search, because two present jobs were treated as equal.
- The list now always picks one org with a stable ranking.

## Changes
- Rank current orgs: allowed over blocked, then primary, then dated, then longer date range (oldest start when both are present), then id.
- Always load `allowAffiliation` / `isPrimaryWorkExperience` on member orgs, and order by `createdAt, id` so equal timestamps stay stable.