### PR TITLE
feat: add manual api (CM-1390)

### DIFF
--- a/backend/src/api/index.ts
+++ b/backend/src/api/index.ts
@@ -252,6 +252,7 @@ setImmediate(async () => {
   require('./dataQuality').default(routes)
   require('./collections').default(routes)
   require('./categories').default(routes)
+  require('./projectCatalog').default(routes)
 
   await require('./nango').default(routes)
 

--- a/backend/src/api/projectCatalog/index.ts
+++ b/backend/src/api/projectCatalog/index.ts
@@ -1,0 +1,5 @@
+import { safeWrap } from '../../middlewares/errorMiddleware'
+
+export default (app) => {
+  app.post('/project-catalog', safeWrap(require('./projectCatalogUpsert').default))
+}

--- a/backend/src/api/projectCatalog/projectCatalogUpsert.ts
+++ b/backend/src/api/projectCatalog/projectCatalogUpsert.ts
@@ -1,4 +1,4 @@
-import { Error400 } from '@crowd/common'
+import { Error400, Error409 } from '@crowd/common'
 import {
   deriveProjectIdentityFromRepoUrl,
   upsertProjectCatalogManualAction,
@@ -9,13 +9,40 @@ import SequelizeRepository from '@/database/repositories/sequelizeRepository'
 import Permissions from '../../security/permissions'
 import PermissionChecker from '../../services/user/permissionChecker'
 
-// 'skip'/'unsure'/'error'/'onboarded' are pipeline outcomes, not manual inputs —
-// claiming them here would fake a result without the work ever running.
 const MANUALLY_ACCEPTABLE_ACTIONS = ['auto', 'evaluate', 'onboard'] as const
 type ManualProjectCatalogAction = (typeof MANUALLY_ACCEPTABLE_ACTIONS)[number]
 
 function isManualProjectCatalogAction(value: unknown): value is ManualProjectCatalogAction {
   return MANUALLY_ACCEPTABLE_ACTIONS.includes(value as ManualProjectCatalogAction)
+}
+
+function canonicalizeGithubRepoUrl(repoUrl: unknown): string | null {
+  if (typeof repoUrl !== 'string') {
+    return null
+  }
+
+  let url: URL
+  try {
+    url = new URL(repoUrl.replace(/^git@github\.com:/, 'https://github.com/'))
+  } catch {
+    return null
+  }
+
+  if (url.hostname !== 'github.com') {
+    return null
+  }
+
+  const parts = url.pathname
+    .replace(/^\//, '')
+    .replace(/\/$/, '')
+    .replace(/\.git$/, '')
+    .split('/')
+
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return null
+  }
+
+  return `https://github.com/${parts[0]}/${parts[1]}`
 }
 
 /**
@@ -31,11 +58,12 @@ function isManualProjectCatalogAction(value: unknown): value is ManualProjectCat
  * @response 200 - Ok
  * @response 400 - Bad request
  * @response 401 - Unauthorized
+ * @response 409 - Already onboarded or onboarding in progress
  */
 export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.projectCatalogEdit)
 
-  const repoUrl = req.body?.repoUrl
+  const repoUrl = canonicalizeGithubRepoUrl(req.body?.repoUrl)
   if (!repoUrl) {
     return req.responseHandler.error(req, res, new Error400(req.language))
   }
@@ -51,11 +79,20 @@ export default async (req, res) => {
   }
 
   const qx = SequelizeRepository.getQueryExecutor(req)
+
   const payload = await upsertProjectCatalogManualAction(qx, {
     ...identity,
     repoUrl,
     action,
   })
+
+  if (!payload) {
+    return req.responseHandler.error(
+      req,
+      res,
+      new Error409(req.language, 'errors.alreadyOnboarded', repoUrl),
+    )
+  }
 
   return req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/projectCatalog/projectCatalogUpsert.ts
+++ b/backend/src/api/projectCatalog/projectCatalogUpsert.ts
@@ -1,0 +1,61 @@
+import { Error400 } from '@crowd/common'
+import {
+  deriveProjectIdentityFromRepoUrl,
+  upsertProjectCatalogManualAction,
+} from '@crowd/data-access-layer'
+
+import SequelizeRepository from '@/database/repositories/sequelizeRepository'
+
+import Permissions from '../../security/permissions'
+import PermissionChecker from '../../services/user/permissionChecker'
+
+// 'skip'/'unsure'/'error'/'onboarded' are pipeline outcomes, not manual inputs —
+// claiming them here would fake a result without the work ever running.
+const MANUALLY_ACCEPTABLE_ACTIONS = ['auto', 'evaluate', 'onboard'] as const
+type ManualProjectCatalogAction = (typeof MANUALLY_ACCEPTABLE_ACTIONS)[number]
+
+function isManualProjectCatalogAction(value: unknown): value is ManualProjectCatalogAction {
+  return MANUALLY_ACCEPTABLE_ACTIONS.includes(value as ManualProjectCatalogAction)
+}
+
+/**
+ * POST /project-catalog
+ * @summary Manually upsert a projectCatalog row for any pipeline phase
+ * @tag Project Catalog
+ * @security Bearer
+ * @description Upserts a projectCatalog row with source 'manual' and the
+ * given action, so it gets picked up by the corresponding pipeline stage
+ * (discovery, evaluation, or onboarding) on its next run.
+ * @bodyContent {string} repoUrl - GitHub repo URL (e.g. https://github.com/owner/repo)
+ * @bodyContent {string} action - One of: auto, evaluate, onboard
+ * @response 200 - Ok
+ * @response 400 - Bad request
+ * @response 401 - Unauthorized
+ */
+export default async (req, res) => {
+  new PermissionChecker(req).validateHas(Permissions.values.projectCatalogEdit)
+
+  const repoUrl = req.body?.repoUrl
+  if (!repoUrl) {
+    return req.responseHandler.error(req, res, new Error400(req.language))
+  }
+
+  const action = req.body?.action
+  if (!isManualProjectCatalogAction(action)) {
+    return req.responseHandler.error(req, res, new Error400(req.language))
+  }
+
+  const identity = deriveProjectIdentityFromRepoUrl(repoUrl)
+  if (!identity) {
+    return req.responseHandler.error(req, res, new Error400(req.language))
+  }
+
+  const qx = SequelizeRepository.getQueryExecutor(req)
+  const payload = await upsertProjectCatalogManualAction(qx, {
+    ...identity,
+    repoUrl,
+    action,
+  })
+
+  return req.responseHandler.success(req, res, payload)
+}

--- a/backend/src/security/permissions.ts
+++ b/backend/src/security/permissions.ts
@@ -316,6 +316,11 @@ class Permissions {
         id: 'categoryRead',
         allowedRoles: [roles.admin, roles.projectAdmin, roles.readonly],
       },
+
+      projectCatalogEdit: {
+        id: 'projectCatalogEdit',
+        allowedRoles: [roles.admin],
+      },
     }
   }
 

--- a/services/apps/projects_evaluation_worker/src/activities/activities.ts
+++ b/services/apps/projects_evaluation_worker/src/activities/activities.ts
@@ -1,8 +1,8 @@
 import {
+  finalizeProjectCatalogEvaluation,
   findProjectCatalogById,
   findProjectCatalogPendingEvaluation,
   promoteProjectsToEvaluate,
-  updateProjectCatalog,
 } from '@crowd/data-access-layer'
 import { IDbProjectCatalog } from '@crowd/data-access-layer/src/project-catalog/types'
 import { pgpQx } from '@crowd/data-access-layer/src/queryExecutor'
@@ -66,14 +66,21 @@ export async function evaluateAndUpdateProject(project: IDbProjectCatalog): Prom
     source: project.source,
   })
 
-  await updateProjectCatalog(qx, project.id, {
+  const updated = await finalizeProjectCatalogEvaluation(qx, project.id, {
     action: result.outcome,
     evaluationResult: result.evaluationResult,
     evaluationReason: result.evaluationReason,
-    evaluatedAt: new Date().toISOString(),
   })
 
   const elapsedSeconds = ((Date.now() - startTime) / 1000).toFixed(1)
+
+  if (!updated) {
+    log.info(
+      { id: project.id, repoUrl: project.repoUrl, elapsedSeconds },
+      'Project was moved out of evaluate by a manual request while evaluating, discarding result.',
+    )
+    return
+  }
 
   log.info(
     {

--- a/services/apps/projects_evaluation_worker/src/schedules/scheduleProjectsEvaluation.ts
+++ b/services/apps/projects_evaluation_worker/src/schedules/scheduleProjectsEvaluation.ts
@@ -10,7 +10,7 @@ const EVALUATION_ARGS: IEvaluateProjectsInput = {
   batchSize: 50,
   priorityConfig: {
     evaluateLimit: 50,
-    sourcePriority: ['insights-discussions'],
+    sourcePriority: ['manual', 'insights-discussions'],
   },
 }
 

--- a/services/apps/projects_evaluation_worker/src/workflows/evaluateProjects.ts
+++ b/services/apps/projects_evaluation_worker/src/workflows/evaluateProjects.ts
@@ -23,7 +23,7 @@ const evaluateActivities = proxyActivities<typeof activities>({
 
 const DEFAULT_PRIORITY_CONFIG: IPriorityConfig = {
   evaluateLimit: 50,
-  sourcePriority: ['insights-discussions'],
+  sourcePriority: ['manual', 'insights-discussions'],
 }
 
 export async function evaluateProjects(input: IEvaluateProjectsInput = {}): Promise<void> {

--- a/services/libs/common/src/i18n/en.ts
+++ b/services/libs/common/src/i18n/en.ts
@@ -186,6 +186,7 @@ const en = {
       alreadyConnected: 'The following mailing lists are already connected to another project: {0}',
     },
     alreadyExists: '{0}',
+    alreadyOnboarded: 'Repo {0} is already onboarded or onboarding is in progress.',
     organization: {
       unmerge: {
         errors: {

--- a/services/libs/common/src/i18n/es.ts
+++ b/services/libs/common/src/i18n/es.ts
@@ -61,6 +61,7 @@ const es = {
     validation: {
       message: 'Ocurrió un error',
     },
+    alreadyOnboarded: 'El repositorio {0} ya está incorporado o la incorporación está en curso.',
   },
   email: {
     error: 'El proveedor de correo electrónico no está configurado.',

--- a/services/libs/common/src/i18n/pt-BR.ts
+++ b/services/libs/common/src/i18n/pt-BR.ts
@@ -66,6 +66,7 @@ const ptBR = {
     validation: {
       message: 'Ocorreu um erro',
     },
+    alreadyOnboarded: 'O repositório {0} já foi integrado ou a integração está em andamento.',
   },
 
   email: {

--- a/services/libs/data-access-layer/src/project-catalog/deriveProjectIdentity.ts
+++ b/services/libs/data-access-layer/src/project-catalog/deriveProjectIdentity.ts
@@ -1,0 +1,17 @@
+export function deriveProjectIdentityFromRepoUrl(
+  repoUrl: string,
+): { projectSlug: string; repoName: string } | null {
+  let urlPath: string
+  try {
+    urlPath = new URL(repoUrl).pathname.replace(/^\//, '').replace(/\/$/, '')
+  } catch {
+    urlPath = repoUrl.replace(/\/$/, '').split('/').slice(-2).join('/')
+  }
+
+  const repoName = urlPath.split('/').pop() || ''
+  if (!urlPath || !repoName) {
+    return null
+  }
+
+  return { projectSlug: urlPath, repoName }
+}

--- a/services/libs/data-access-layer/src/project-catalog/index.ts
+++ b/services/libs/data-access-layer/src/project-catalog/index.ts
@@ -1,2 +1,3 @@
 export * from './types'
 export * from './projectCatalog'
+export * from './deriveProjectIdentity'

--- a/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
+++ b/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
@@ -389,7 +389,7 @@ export async function upsertProjectCatalogManualAction(
     ON CONFLICT ("repoUrl") DO UPDATE SET
       "projectSlug" = EXCLUDED."projectSlug",
       "repoName" = EXCLUDED."repoName",
-      "source" = COALESCE("projectCatalog"."source", 'manual'),
+      "source" = 'manual',
       "action" = EXCLUDED."action",
       "evaluatedAt" = CASE
         WHEN EXCLUDED."action" IN ('auto', 'evaluate') THEN NULL
@@ -405,16 +405,8 @@ export async function upsertProjectCatalogManualAction(
       END,
       "updatedAt" = NOW(),
       "syncedAt" = NOW()
-    WHERE (
-        "projectCatalog"."onboardedAt" IS NULL
-        AND "projectCatalog"."action" NOT IN ('onboard', 'onboarded')
-      )
-      -- automatic_onboarding_worker's workflowExecutionTimeout caps a legitimate run at 6h;
-      -- past that a stuck 'onboard' row is safe to reclaim manually.
-      OR (
-        "projectCatalog"."action" = 'onboard'
-        AND "projectCatalog"."updatedAt" < NOW() - INTERVAL '8 hours'
-      )
+    WHERE "projectCatalog"."onboardedAt" IS NULL
+      AND "projectCatalog"."action" NOT IN ('onboard', 'onboarded')
     RETURNING ${prepareSelectColumns(PROJECT_CATALOG_COLUMNS)}
     `,
     data,
@@ -572,6 +564,31 @@ export async function markProjectCatalogOnboardingFailed(
     WHERE id = $(id) AND "action" = 'onboard' AND "onboardedAt" IS NULL
     `,
     { id, reason },
+  )
+}
+
+// Guarded like markProjectCatalogOnboardingFailed above: a manual request
+// (POST /project-catalog) may have moved the row out of 'evaluate' while this
+// evaluation was in flight — in that case the manual action wins and this
+// write is a no-op.
+export async function finalizeProjectCatalogEvaluation(
+  qx: QueryExecutor,
+  id: string,
+  data: { action: ProjectCatalogAction; evaluationResult: string; evaluationReason: string },
+): Promise<IDbProjectCatalog | null> {
+  return qx.selectOneOrNone(
+    `
+    UPDATE "projectCatalog"
+    SET
+      "action" = $(action),
+      "evaluationResult" = $(evaluationResult),
+      "evaluationReason" = $(evaluationReason),
+      "evaluatedAt" = NOW(),
+      "updatedAt" = NOW()
+    WHERE id = $(id) AND "action" = 'evaluate' AND "evaluatedAt" IS NULL
+    RETURNING ${prepareSelectColumns(PROJECT_CATALOG_COLUMNS)}
+    `,
+    { id, ...data },
   )
 }
 

--- a/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
+++ b/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
@@ -98,7 +98,10 @@ export async function findProjectCatalogPendingEvaluation(
     SELECT ${prepareSelectColumns(PROJECT_CATALOG_COLUMNS)}
     FROM "projectCatalog"
     WHERE action = 'evaluate'
-    ORDER BY "lfCriticalityScore" DESC NULLS LAST, "createdAt" ASC
+    ORDER BY
+      (source = 'manual') DESC NULLS LAST,
+      "lfCriticalityScore" DESC NULLS LAST,
+      "createdAt" ASC
     ${limit !== undefined ? 'LIMIT $(limit)' : ''}
     ${offset !== undefined ? 'OFFSET $(offset)' : ''}
     `,

--- a/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
+++ b/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
@@ -363,8 +363,8 @@ export async function upsertProjectCatalog(
 export async function upsertProjectCatalogManualAction(
   qx: QueryExecutor,
   data: { projectSlug: string; repoName: string; repoUrl: string; action: ProjectCatalogAction },
-): Promise<IDbProjectCatalog> {
-  return qx.selectOne(
+): Promise<IDbProjectCatalog | null> {
+  return qx.selectOneOrNone(
     `
     INSERT INTO "projectCatalog" (
       "projectSlug",
@@ -389,8 +389,12 @@ export async function upsertProjectCatalogManualAction(
     ON CONFLICT ("repoUrl") DO UPDATE SET
       "projectSlug" = EXCLUDED."projectSlug",
       "repoName" = EXCLUDED."repoName",
-      "source" = 'manual',
+      "source" = COALESCE("projectCatalog"."source", 'manual'),
       "action" = EXCLUDED."action",
+      "evaluatedAt" = CASE
+        WHEN EXCLUDED."action" IN ('auto', 'evaluate') THEN NULL
+        ELSE "projectCatalog"."evaluatedAt"
+      END,
       "onboardedAt" = CASE
         WHEN EXCLUDED."action" = 'onboard' THEN NULL
         ELSE "projectCatalog"."onboardedAt"
@@ -401,6 +405,16 @@ export async function upsertProjectCatalogManualAction(
       END,
       "updatedAt" = NOW(),
       "syncedAt" = NOW()
+    WHERE (
+        "projectCatalog"."onboardedAt" IS NULL
+        AND "projectCatalog"."action" NOT IN ('onboard', 'onboarded')
+      )
+      -- automatic_onboarding_worker's workflowExecutionTimeout caps a legitimate run at 6h;
+      -- past that a stuck 'onboard' row is safe to reclaim manually.
+      OR (
+        "projectCatalog"."action" = 'onboard'
+        AND "projectCatalog"."updatedAt" < NOW() - INTERVAL '8 hours'
+      )
     RETURNING ${prepareSelectColumns(PROJECT_CATALOG_COLUMNS)}
     `,
     data,

--- a/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
+++ b/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
@@ -360,6 +360,53 @@ export async function upsertProjectCatalog(
   )
 }
 
+export async function upsertProjectCatalogManualAction(
+  qx: QueryExecutor,
+  data: { projectSlug: string; repoName: string; repoUrl: string; action: ProjectCatalogAction },
+): Promise<IDbProjectCatalog> {
+  return qx.selectOne(
+    `
+    INSERT INTO "projectCatalog" (
+      "projectSlug",
+      "repoName",
+      "repoUrl",
+      "source",
+      "action",
+      "createdAt",
+      "updatedAt",
+      "syncedAt"
+    )
+    VALUES (
+      $(projectSlug),
+      $(repoName),
+      $(repoUrl),
+      'manual',
+      $(action),
+      NOW(),
+      NOW(),
+      NOW()
+    )
+    ON CONFLICT ("repoUrl") DO UPDATE SET
+      "projectSlug" = EXCLUDED."projectSlug",
+      "repoName" = EXCLUDED."repoName",
+      "source" = 'manual',
+      "action" = EXCLUDED."action",
+      "onboardedAt" = CASE
+        WHEN EXCLUDED."action" = 'onboard' THEN NULL
+        ELSE "projectCatalog"."onboardedAt"
+      END,
+      "onboardingError" = CASE
+        WHEN EXCLUDED."action" = 'onboard' THEN NULL
+        ELSE "projectCatalog"."onboardingError"
+      END,
+      "updatedAt" = NOW(),
+      "syncedAt" = NOW()
+    RETURNING ${prepareSelectColumns(PROJECT_CATALOG_COLUMNS)}
+    `,
+    data,
+  )
+}
+
 export async function bulkUpsertProjectCatalog(
   qx: QueryExecutor,
   items: IDbProjectCatalogCreate[],

--- a/services/libs/data-access-layer/src/project-catalog/types.ts
+++ b/services/libs/data-access-layer/src/project-catalog/types.ts
@@ -1,11 +1,14 @@
-export type ProjectCatalogAction =
-  | 'auto'
-  | 'evaluate'
-  | 'onboard'
-  | 'onboarded'
-  | 'skip'
-  | 'unsure'
-  | 'error'
+export const PROJECT_CATALOG_ACTIONS = [
+  'auto',
+  'evaluate',
+  'onboard',
+  'onboarded',
+  'skip',
+  'unsure',
+  'error',
+] as const
+
+export type ProjectCatalogAction = (typeof PROJECT_CATALOG_ACTIONS)[number]
 
 export interface IDbProjectCatalog {
   id: string


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? -->
<!-- Example: Adds batch processing for member enrichment to reduce API calls -->
Adds a manual `POST /project-catalog` endpoint so an admin can insert or re-drive a
`projectCatalog` row for any pipeline phase (discovery, evaluation, onboarding) without
waiting for the automatic discovery workers. This unblocks manually onboarding
individual repos requested outside the normal discovery flow (e.g. community
requests), while keeping the action space restricted to states that make sense as a
human-triggered input.

## Changes
<!-- Bullet list of what changed. Focus on non-obvious decisions. -->
- New internal route `POST /project-catalog`, guarded by a new `projectCatalogEdit` permission (admin-only).
- Request body accepts `repoUrl` and `action`, where `action` is restricted to `auto | evaluate | onboard` — `skip`/`unsure`/`error`/`onboarded` are pipeline *outcomes*, not valid manual inputs, so they're rejected as unacceptable state.
- Added `upsertProjectCatalogManualAction` in `data-access-layer`, a separate upsert from the existing `upsertProjectCatalog`: the existing one guards against re-syncs clobbering already-advanced state (used by discovery workers), while this one unconditionally applies the requested `action` since a manual call is a deliberate human override. It also resets `onboardedAt`/`onboardingError` to `NULL` when the new action is `onboard`, so a manually re-queued row becomes eligible again for onboarding pickup.
- Extracted `deriveProjectIdentityFromRepoUrl` as a shared helper in `data-access-layer/project-catalog`, instead of duplicating repo-URL parsing a third time in the new handler (already duplicated twice across the discovery workers). The two pre-existing discovery-worker copies were left untouched — out of scope for this change.
- No DB migration needed; `projectCatalog.action` remains a free-text `VARCHAR(16)` with no CHECK constraint.


## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1390](https://linuxfoundation.atlassian.net/browse/CM-1390)

[CM-1390]: https://linuxfoundation.atlassian.net/browse/CM-1390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ