### PR TITLE
fix: resolve collectionsInsightsProjects version tie in tinybird pipes

### DIFF
--- a/services/libs/tinybird/pipes/collections_filtered.pipe
+++ b/services/libs/tinybird/pipes/collections_filtered.pipe
@@ -26,7 +26,14 @@ SQL >
         ) as "projectCount"
     FROM collections FINAL
     left join
-        collectionsInsightsProjects
+        (
+            SELECT
+                collectionId,
+                insightsProjectId,
+                argMax(deletedAt, (updatedAt, isNull(deletedAt))) AS deletedAt
+            FROM collectionsInsightsProjects
+            GROUP BY collectionId, insightsProjectId
+        ) collectionsInsightsProjects
         on collectionsInsightsProjects.collectionId = collections.id
         and isNull (collectionsInsightsProjects.deletedAt)
     left join

--- a/services/libs/tinybird/pipes/collections_list.pipe
+++ b/services/libs/tinybird/pipes/collections_list.pipe
@@ -75,7 +75,15 @@ SQL >
     SELECT collectionsInsightsProjects.collectionId, insightsProjects_filtered.*
     from insightsProjects_filtered
     join
-        collectionsInsightsProjects final
+        (
+            SELECT
+                collectionId,
+                insightsProjectId,
+                argMax(starred, (updatedAt, isNull(deletedAt))) AS starred,
+                argMax(deletedAt, (updatedAt, isNull(deletedAt))) AS deletedAt
+            FROM collectionsInsightsProjects
+            GROUP BY collectionId, insightsProjectId
+        ) collectionsInsightsProjects
         on collectionsInsightsProjects.insightsProjectId = insightsProjects_filtered.id
     where
         (collectionsInsightsProjects.collectionId in (select id from collections_paginated))

--- a/services/libs/tinybird/pipes/collections_oss_index.pipe
+++ b/services/libs/tinybird/pipes/collections_oss_index.pipe
@@ -121,7 +121,14 @@ SQL >
 NODE collections_oss_index_projects_count
 SQL >
     SELECT collectionId, count(insightsProjectId) as projectCount
-    FROM collectionsInsightsProjects
+    FROM (
+        SELECT
+            collectionId,
+            insightsProjectId,
+            argMax(deletedAt, (updatedAt, isNull(deletedAt))) AS deletedAt
+        FROM collectionsInsightsProjects
+        GROUP BY collectionId, insightsProjectId
+    )
     WHERE collectionId != '' AND isNull (deletedAt)
     GROUP BY collectionId
 

--- a/services/libs/tinybird/pipes/insights_projects_populated_copy.pipe
+++ b/services/libs/tinybird/pipes/insights_projects_populated_copy.pipe
@@ -10,7 +10,14 @@ DESCRIPTION >
 
 SQL >
     SELECT cip.insightsProjectId, groupArray(c.slug) AS "collectionsSlugs"
-    FROM collectionsInsightsProjects cip FINAL
+    FROM (
+        SELECT
+            collectionId,
+            insightsProjectId,
+            argMax(deletedAt, (updatedAt, isNull(deletedAt))) AS deletedAt
+        FROM collectionsInsightsProjects
+        GROUP BY collectionId, insightsProjectId
+    ) cip
     JOIN collections c FINAL ON c.id = cip.collectionId
     WHERE isNull (c.deletedAt) AND isNull (cip.deletedAt)
     GROUP BY cip.insightsProjectId


### PR DESCRIPTION
## Summary

- `collectionsInsightsProjects` is a `ReplacingMergeTree` with `updatedAt` as `ENGINE_VER`. The 2026-07-17 CNCF membership reassignment emitted a delete and a re-insert with the same `updatedAt` (same `now()` window), leaving ~117 pairs with a version tie. `FINAL` picks arbitrarily — for those 117 it kept the deleted row, causing 117 CNCF projects to silently drop from the collection widget (~14.2k contributors missing).
- Replace every `FROM collectionsInsightsProjects [FINAL]` read across 4 pipes with an `argMax` dedup subquery that tie-breaks toward the live row: `argMax(deletedAt, (updatedAt, isNull(deletedAt)))`. On equal `updatedAt`, `isNull=1` (live) beats `isNull=0` (deleted).
- Affected pipes: `insights_projects_populated_copy`, `collections_list`, `collections_filtered`, `collections_oss_index`. `collections_filtered` and `collections_oss_index` also lacked `FINAL` entirely, so they were double-counting duplicates before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)