### PR TITLE
fix: resolve repo segment by URL only during activity ingestion (CM-1404)

### DIFF
--- a/services/libs/data-access-layer/src/repositories/index.ts
+++ b/services/libs/data-access-layer/src/repositories/index.ts
@@ -413,10 +413,9 @@ function getRepoSegmentLookupCache(redis: RedisClient, log: Logger): RedisCache 
 }
 
 /**
- * Find segment IDs for repositories by sourceIntegrationId and URL (no caching)
- * @param qx - Query executor
- * @param toFind - Array of { integrationId, url } to look up (integrationId = sourceIntegrationId)
- * @returns Array of { integrationId, url, segmentId } results
+ * Find segment IDs for repositories by URL (no caching).
+ * The repository URL is the authoritative key: segmentId in public.repositories
+ * is the project mapping and does not depend on which integration is ingesting.
  */
 async function findSegmentsForReposFromDb(
   qx: QueryExecutor,
@@ -426,41 +425,24 @@ async function findSegmentsForReposFromDb(
     return []
   }
 
-  const orConditions: string[] = []
-  const params: Record<string, string> = {}
+  const distinctUrls = Array.from(new Set(toFind.map((r) => r.url)))
 
-  let index = 0
-  for (const repo of toFind) {
-    const urlKey = `url_${index}`
-    const integrationKey = `integration_${index}`
-    index++
-
-    orConditions.push(`(url = $(${urlKey}) AND "sourceIntegrationId" = $(${integrationKey}))`)
-    params[urlKey] = repo.url
-    params[integrationKey] = repo.integrationId
-  }
-
-  const dbResults: { integrationId: string; url: string; segmentId: string }[] = await qx.select(
+  const dbResults: { url: string; segmentId: string }[] = await qx.select(
     `
-    SELECT "sourceIntegrationId" AS "integrationId", url, "segmentId"
+    SELECT url, "segmentId"
     FROM public.repositories
-    WHERE "deletedAt" IS NULL AND (${orConditions.join(' OR ')})
-    LIMIT ${toFind.length}
+    WHERE "deletedAt" IS NULL AND url IN ($(urls:csv))
     `,
-    params,
+    { urls: distinctUrls },
   )
 
-  // Build results with undefined for not found repos
-  return toFind.map((repo) => {
-    const found = dbResults.find(
-      (r) => r.integrationId === repo.integrationId && r.url === repo.url,
-    )
-    return {
-      integrationId: repo.integrationId,
-      url: repo.url,
-      segmentId: found?.segmentId,
-    }
-  })
+  const byUrl = new Map(dbResults.map((r) => [r.url, r.segmentId]))
+
+  return toFind.map((repo) => ({
+    integrationId: repo.integrationId,
+    url: repo.url,
+    segmentId: byUrl.get(repo.url),
+  }))
 }
 
 /**
@@ -511,8 +493,7 @@ export async function findSegmentsForRepos(
   for (const repo of toFind) {
     cachePromises.push(
       (async () => {
-        const key = `${repo.integrationId}:${repo.url}`
-        const cached = await cache.get(key)
+        const cached = await cache.get(repo.url)
         if (cached) {
           results.push({
             integrationId: repo.integrationId,
@@ -526,18 +507,14 @@ export async function findSegmentsForRepos(
 
   await Promise.all(cachePromises)
 
-  // Find repos that weren't in cache
-  const remainingRepos = toFind.filter(
-    (r) =>
-      results.find((e) => e.integrationId === r.integrationId && e.url === r.url) === undefined,
-  )
+  const remainingRepos = toFind.filter((r) => results.find((e) => e.url === r.url) === undefined)
 
   if (remainingRepos.length > 0) {
     const dbResults = await findSegmentsForReposFromDb(qx, remainingRepos)
 
     const setCachePromises: Promise<void>[] = []
     for (const result of dbResults) {
-      const key = `${result.integrationId}:${result.url}`
+      const key = result.url
       results.push(result)
 
       if (result.segmentId) {


### PR DESCRIPTION
## Summary

- Repo → segment lookup during activity ingestion filtered on both `url` AND `sourceIntegrationId`. When an umbrella-org integration (e.g. `kubernetes-sigs` under the Kubernetes integration) crawls a repo whose `public.repositories` row lists a different `sourceIntegrationId` (e.g. the Headlamp integration), the lookup missed and the activity inherited the ingesting integration's `segmentId` — landing in the wrong segment.
- Fix: query `public.repositories` by URL only. The `segmentId` there is the authoritative project mapping.
- Redis cache key is now the URL only, so per-integration stale entries cannot linger.

## Bug evidence

`kubernetes-sigs/headlamp` in the last 24h:
- `ef06ac44…` Headlamp (correct) — 262,611 activities / 9,255 relations, last 2026-08-31 21:06
- `e9eaa61c…` Kubernetes (wrong) — 228,267 activities / 7,989 relations, last 2026-08-31 18:57

Scan of `activityRelations` for the last 2 days: **48 distinct repos** ingested into more than one segment. **1,376 wrong-segment activityRelations** vs 1,813 correct. Top examples:

| Repo | Correct segment | Wrong segment | Wrong / 2d |
|---|---|---|---|
| kubernetes-sigs/headlamp | Headlamp | Kubernetes | 225 |

## Origin

Bug present since `f28f6616e feat(data-sink-woker): use repositories table for repo segment lookup [CM-899]` (#3762). Not a recent regression.

## Follow-up (not in this PR)

- Backfill / re-segment existing mis-ingested activityRelations rows for the 48 (+ any long-tail) affected repos.
- Optional: flush `repoSegmentLookup:*` Redis keys on deploy — old `${integrationId}:${url}` entries become dead weight (never read).

Closes CM-1404.

[CM-899]: https://linuxfoundation.atlassian.net/browse/CM-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ