### PR TITLE
feat: secondary manifest repository signal (CM-1393)

### DIFF
--- a/docs/adr/0021-secondary-manifest-repository-signal.md
+++ b/docs/adr/0021-secondary-manifest-repository-signal.md
@@ -28,7 +28,7 @@ One shared helper, `resolveManifestRepo(candidates)`
 (`packages_worker/src/utils/resolveManifestRepo.ts`), resolves a package's repo
 from an ordered candidate list. The first candidate is the ecosystem's canonical
 field and resolves as `primary`; every later candidate resolves as `secondary`.
-The result carries `{ repo, signal, field }`, and each writer persists the
+The result carries `{ repo, signal }`, and each writer persists the
 returned `signal` on the link. No writer computes a confidence value.
 
 ### Chains
@@ -58,43 +58,6 @@ SQL over a dump, so `normalizeRepos` stages both `declared_repository_url` and
 first-wins-with-host-gate rule in SQL. `documentation` is not staged — it is
 almost always docs.rs, which the host gate rejects anyway.
 
-## Alternatives Considered
-
-### Alternative 1: Widen each writer's existing extractor in place
-
-- **Pros**: no new module; smallest diff per ecosystem.
-- **Cons**: seven copies of the fallback order and the host gate, which is how
-  the current per-ecosystem divergence arose in the first place; the `signal`
-  value would be derived independently in each writer.
-- **Why not**: the whole point is one rule; nine implementations of "which
-  field won" is the defect, not the fix.
-
-### Alternative 2: Accept fallback URLs on any host, like the primary field does
-
-- **Pros**: maximum coverage; no URL is discarded.
-- **Cons**: a documentation site or a marketing page with two path segments
-  becomes a repo link, creating a `repos` row and an incorrect
-  `packages_published` attribution — the exact failure this epic exists to fix.
-- **Why not**: coverage gained by inventing repos is negative value; the
-  primary field at least carries the publisher's explicit claim.
-
-### Alternative 3: Score fallback links lower directly in the writers instead of adding `signal`
-
-- **Pros**: no schema column; visible in one place.
-- **Cons**: reintroduces per-writer confidence literals, and the penalty could
-  not be retuned or audited afterwards — nothing records *why* a row scored
-  lower.
-- **Why not**: ADR-0020 makes the stored score derivable from stored evidence;
-  `signal` is that evidence.
-
-### Alternative 4: Backfill a separate pass that mines fallback fields for packages with no link
-
-- **Pros**: zero risk to the existing write paths; can be re-run at will.
-- **Cons**: a second code path that has to re-fetch or re-read every manifest,
-  and it goes stale the moment a package is re-ingested.
-- **Why not**: the data is already in hand at write time; the write path is
-  the cheapest place to fix coverage.
-
 ## Consequences
 
 ### Positive
@@ -110,8 +73,9 @@ almost always docs.rs, which the host gate rejects anyway.
 
 - Secondary links are, by construction, less certain than declared ones; some
   will be wrong even with the host gate.
-- Maven and cargo needed local restructuring (maven onto the shared
-  canonicalizer, cargo's `repo_choice` in SQL) to reach the same behaviour.
+- Maven and cargo needed local restructuring (maven's POM-specific
+  `normalizeScmUrl` feeds the same `package_repos` write path; cargo's
+  `repo_choice` applies the host-gate rule in SQL) to reach the same behaviour.
 - Row counts in `package_repos` grow, and the dedup/keep-highest path now sees
   more competing links per package.
 

--- a/docs/adr/0021-secondary-manifest-repository-signal.md
+++ b/docs/adr/0021-secondary-manifest-repository-signal.md
@@ -1,0 +1,131 @@
+# ADR-0021: Secondary manifest repository signal
+
+**Date**: 2026-09-01
+**Status**: accepted
+**Deciders**: Joana Maia
+
+## Context
+
+Every registry writer only created a `package_repos` row when the ecosystem's
+canonical repository field parsed — npm `repository`, cargo `repository`,
+rubygems `source_code_uri`, NuGet `<repository>`, POM `<scm><url>`. A large
+share of packages leave that field empty while publishing the same repo URL in
+`homepage`, `bugs.url`, `projectUrl`, `bug_tracker_uri`, or the POM `<url>`, and
+those packages ended up with no repo link at all — invisible to criticality,
+blast radius, and Insights.
+
+Simply widening each writer to accept any of those fields would trade
+under-coverage for wrong links: fallback fields are free-form, so
+`https://example.com/docs/getting-started` canonicalizes into a plausible
+`owner/repo` shape without being a repository. Fallback links also should not
+rank equally with a declared one.
+[ADR-0020](./0020-package-repo-confidence-scoring.md) already reserved the
+`signal` column and its −0.10 penalty for exactly this.
+
+## Decision
+
+One shared helper, `resolveManifestRepo(candidates)`
+(`packages_worker/src/utils/resolveManifestRepo.ts`), resolves a package's repo
+from an ordered candidate list. The first candidate is the ecosystem's canonical
+field and resolves as `primary`; every later candidate resolves as `secondary`.
+The result carries `{ repo, signal, field }`, and each writer persists the
+returned `signal` on the link. No writer computes a confidence value.
+
+### Chains
+
+| Ecosystem | Chain |
+| --- | --- |
+| npm | `repository` → `homepage` → `bugs.url` |
+| pypi | Source/Code project URL → `Homepage` → bug tracker URL |
+| cargo | `repository` → `homepage` |
+| rubygems | `source_code_uri` → `homepage_uri` → `bug_tracker_uri` |
+| packagist | `support.source` → `homepage` |
+| nuget | `<repository>` → `projectUrl` |
+| maven | POM `<scm><url>` → POM `<url>` |
+
+### Host gate
+
+Candidates go through the shared `canonicalizeRepoUrl`. A `secondary` candidate
+is rejected when canonicalization yields `host === 'other'` — recognized VCS
+hosts only. The `primary` candidate keeps its historical behaviour and still
+accepts `other`, so existing links to self-hosted Gitea, cgit, and SVN are
+unaffected. Packagist already applied this gate locally; it is now the shared
+rule.
+
+Cargo is the exception on mechanics, not on policy: its pipeline is set-based
+SQL over a dump, so `normalizeRepos` stages both `declared_repository_url` and
+`homepage` into `repo_norm`, and a new `repo_choice` table applies the same
+first-wins-with-host-gate rule in SQL. `documentation` is not staged — it is
+almost always docs.rs, which the host gate rejects anyway.
+
+## Alternatives Considered
+
+### Alternative 1: Widen each writer's existing extractor in place
+
+- **Pros**: no new module; smallest diff per ecosystem.
+- **Cons**: seven copies of the fallback order and the host gate, which is how
+  the current per-ecosystem divergence arose in the first place; the `signal`
+  value would be derived independently in each writer.
+- **Why not**: the whole point is one rule; nine implementations of "which
+  field won" is the defect, not the fix.
+
+### Alternative 2: Accept fallback URLs on any host, like the primary field does
+
+- **Pros**: maximum coverage; no URL is discarded.
+- **Cons**: a documentation site or a marketing page with two path segments
+  becomes a repo link, creating a `repos` row and an incorrect
+  `packages_published` attribution — the exact failure this epic exists to fix.
+- **Why not**: coverage gained by inventing repos is negative value; the
+  primary field at least carries the publisher's explicit claim.
+
+### Alternative 3: Score fallback links lower directly in the writers instead of adding `signal`
+
+- **Pros**: no schema column; visible in one place.
+- **Cons**: reintroduces per-writer confidence literals, and the penalty could
+  not be retuned or audited afterwards — nothing records *why* a row scored
+  lower.
+- **Why not**: ADR-0020 makes the stored score derivable from stored evidence;
+  `signal` is that evidence.
+
+### Alternative 4: Backfill a separate pass that mines fallback fields for packages with no link
+
+- **Pros**: zero risk to the existing write paths; can be re-run at will.
+- **Cons**: a second code path that has to re-fetch or re-read every manifest,
+  and it goes stale the moment a package is re-ingested.
+- **Why not**: the data is already in hand at write time; the write path is
+  the cheapest place to fix coverage.
+
+## Consequences
+
+### Positive
+
+- Packages that only publish their repo in a secondary field now get a link,
+  and the link is honestly labelled as weaker.
+- The fallback order and the host gate exist once, so adding an ecosystem means
+  declaring a candidate list.
+- Per-run counters (`primary_field_hit`, `fallback_hit_by_field`, `no_signal`)
+  make the coverage uplift measurable against the pre-merge baseline.
+
+### Negative
+
+- Secondary links are, by construction, less certain than declared ones; some
+  will be wrong even with the host gate.
+- Maven and cargo needed local restructuring (maven onto the shared
+  canonicalizer, cargo's `repo_choice` in SQL) to reach the same behaviour.
+- Row counts in `package_repos` grow, and the dedup/keep-highest path now sees
+  more competing links per package.
+
+### Risks
+
+- **A secondary link can outrank a genuine one when the declared field is
+  missing on the true repo but present on a fork.** Mitigation: ADR-0020's
+  fork and archived penalties, plus ADR-0022's ownership evidence, which
+  penalises the fork's owner mismatch far more heavily than the secondary
+  penalty.
+- **Recognized-host gating rejects legitimate self-hosted repos found in a
+  fallback field.** Accepted deliberately: an unrecognized host in a free-form
+  field carries no signal that it is a repository at all. Revisit if the
+  `no_signal` counters show a material self-hosted tail.
+- **Coverage growth is hard to attribute after the fact.** Mitigation: record
+  per-ecosystem `package_repos` row counts before merge, and compare against
+  the `fallback_hit_by_field` counters afterwards.

--- a/docs/adr/0021-secondary-manifest-repository-signal.md
+++ b/docs/adr/0021-secondary-manifest-repository-signal.md
@@ -58,6 +58,32 @@ SQL over a dump, so `normalizeRepos` stages both `declared_repository_url` and
 first-wins-with-host-gate rule in SQL. `documentation` is not staged — it is
 almost always docs.rs, which the host gate rejects anyway.
 
+## Alternatives Considered
+
+### Per-ecosystem fallback (no shared helper)
+
+Each registry writer would duplicate its own fallback chain — npm already tried
+`bugs.url`, packagist already tried `homepage`.
+
+**Pros:** no new abstraction; each writer stays self-contained.
+**Cons:** seven writers meant seven copies of the same ordered-candidate logic
+and seven copies of the host-gate rule; adding a new ecosystem requires knowing
+which copy to follow.
+**Why not:** the duplication already caused drift (packagist's host gate existed
+alone; npm had no gate at all); a single helper enforces the rule once.
+
+### Accept all fallback fields at `primary` confidence
+
+Widen each writer to try secondary fields but record every link as `primary`.
+
+**Pros:** simpler persistence — no signal column needed.
+**Cons:** free-form fields (`homepage`, `projectUrl`) are noisy; ranking a
+documentation site equal to an explicit `<scm>` declaration inflates wrong
+links and corrupts the confidence score distribution.
+**Why not:** ADR-0020 already reserved the `signal` column and its −0.10 penalty
+specifically to express this distinction; a flat approach would abandon that
+mechanism before it could be used.
+
 ## Consequences
 
 ### Positive

--- a/docs/adr/0021-secondary-manifest-repository-signal.md
+++ b/docs/adr/0021-secondary-manifest-repository-signal.md
@@ -60,29 +60,40 @@ almost always docs.rs, which the host gate rejects anyway.
 
 ## Alternatives Considered
 
-### Per-ecosystem fallback (no shared helper)
+### Alternative 1: Widen each writer's existing extractor in place
 
-Each registry writer would duplicate its own fallback chain — npm already tried
-`bugs.url`, packagist already tried `homepage`.
+- **Pros**: no new module; smallest diff per ecosystem.
+- **Cons**: seven copies of the fallback order and the host gate, which is how
+  the current per-ecosystem divergence arose in the first place; the `signal`
+  value would be derived independently in each writer.
+- **Why not**: the whole point is one rule; nine implementations of "which
+  field won" is the defect, not the fix.
 
-**Pros:** no new abstraction; each writer stays self-contained.
-**Cons:** seven writers meant seven copies of the same ordered-candidate logic
-and seven copies of the host-gate rule; adding a new ecosystem requires knowing
-which copy to follow.
-**Why not:** the duplication already caused drift (packagist's host gate existed
-alone; npm had no gate at all); a single helper enforces the rule once.
+### Alternative 2: Accept fallback URLs on any host, like the primary field does
 
-### Accept all fallback fields at `primary` confidence
+- **Pros**: maximum coverage; no URL is discarded.
+- **Cons**: a documentation site or a marketing page with two path segments
+  becomes a repo link, creating a `repos` row and an incorrect
+  `packages_published` attribution — the exact failure this epic exists to fix.
+- **Why not**: coverage gained by inventing repos is negative value; the
+  primary field at least carries the publisher's explicit claim.
 
-Widen each writer to try secondary fields but record every link as `primary`.
+### Alternative 3: Score fallback links lower directly in the writers instead of adding `signal`
 
-**Pros:** simpler persistence — no signal column needed.
-**Cons:** free-form fields (`homepage`, `projectUrl`) are noisy; ranking a
-documentation site equal to an explicit `<scm>` declaration inflates wrong
-links and corrupts the confidence score distribution.
-**Why not:** ADR-0020 already reserved the `signal` column and its −0.10 penalty
-specifically to express this distinction; a flat approach would abandon that
-mechanism before it could be used.
+- **Pros**: no schema column; visible in one place.
+- **Cons**: reintroduces per-writer confidence literals, and the penalty could
+  not be retuned or audited afterwards — nothing records *why* a row scored
+  lower.
+- **Why not**: ADR-0020 makes the stored score derivable from stored evidence;
+  `signal` is that evidence.
+
+### Alternative 4: Backfill a separate pass that mines fallback fields for packages with no link
+
+- **Pros**: zero risk to the existing write paths; can be re-run at will.
+- **Cons**: a second code path that has to re-fetch or re-read every manifest,
+  and it goes stale the moment a package is re-ingested.
+- **Why not**: the data is already in hand at write time; the write path is
+  the cheapest place to fix coverage.
 
 ## Consequences
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,7 @@ Use the `/adr` skill in Claude Code to record new ADRs or query past decisions.
 | [ADR-0018](./0018-per-client-rate-limiting-members-resolve.md) | Per-client rate limiting for `POST /members/resolve` using in-memory store                           | accepted | 2026-08-12 |
 | [ADR-0019](./0019-docker-builder-runner-libc.md)               | Same libc in Docker builder and runner                                                               | accepted | 2026-08-27 |
 | [ADR-0020](./0020-package-repo-confidence-scoring.md)          | Deterministic package→repo confidence scoring                                                        | accepted | 2026-09-01 |
+| [ADR-0021](./0021-secondary-manifest-repository-signal.md)     | Secondary manifest repository signal                                                                 | accepted | 2026-09-01 |
 
 ## Why ADRs?
 

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -201,15 +201,11 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
        SELECT (SELECT COUNT(*) FROM new_repos)::int AS repos`,
     )
 
-    // Prunes stale 'declared' links before relinking — covers junk/unparseable declared
-    // values, rewrites (declared URL now maps elsewhere), and removals (this dump's
-    // declared_repository_url is NULL, meaning the crate no longer declares a repo at
-    // all — loadDump.ts stages every matched crate every run, so NULL here is
-    // authoritative, not "no data this run"). Safe to always prune on that signal because
-    // the DELETE is scoped to source = 'declared' — cargo only ever removes links it owns.
-    // Without this, package_repos would accumulate a link to a repo no crate declares
-    // anymore, and consumers such as security-contacts (which join through
-    // repos ⋈ package_repos, not packages.repository_url) would keep reading it.
+    // Unconditionally prunes all cargo-owned declared links before relinking. Covers:
+    // removals (NULL in this dump is authoritative — loadDump stages every crate every run),
+    // URL rewrites, junk/unparseable values, and primary→secondary signal downgrades on the
+    // same URL (keep-highest would otherwise block the downgrade). Scoped to source =
+    // 'declared' so only cargo-owned rows are touched.
     const pruneRow = await tx.selectOne(
       `WITH targets AS (
          SELECT rc.package_id, r.id AS repo_id
@@ -221,7 +217,6 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
          USING targets t
          WHERE pr.package_id = t.package_id
            AND pr.source = $(source)
-           AND (t.repo_id IS NULL OR pr.repo_id IS DISTINCT FROM t.repo_id)
          RETURNING pr.package_id
        ),
        ins_audit AS (

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -21,7 +21,7 @@ const INGESTION_SOURCE = 'cargo-registry'
 const REPO_LINK_SOURCE = 'declared' // same convention as npm/maven for manifest-declared repo URLs
 const CARGO_CONFIDENCE = packageRepoConfidenceCall('p', 'r', {
   source: '$(source)',
-  signal: "'primary'",
+  signal: 'rc.signal',
   ownershipMatch: "'no_evidence'",
   provenance: 'NULL',
 })
@@ -70,7 +70,7 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            description             = COALESCE(e.description, p.description),
            homepage                = COALESCE(e.homepage, p.homepage),
            declared_repository_url = COALESCE(e.declared_repository_url, p.declared_repository_url),
-           repository_url          = CASE WHEN e.declared_repository_url IS NOT NULL
+           repository_url          = CASE WHEN e.declared_repository_url IS NOT NULL OR rn.repository_url IS NOT NULL
                                           THEN rn.repository_url ELSE p.repository_url END,
            licenses                = COALESCE(e.licenses, p.licenses),
            licenses_raw            = COALESCE(e.licenses_raw, p.licenses_raw),
@@ -85,7 +85,7 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            ingestion_source        = $(ingestionSource),
            last_synced_at          = NOW()
          FROM ${STAGING_SCHEMA}.enrich_packages e
-         LEFT JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
+         LEFT JOIN ${STAGING_SCHEMA}.repo_choice rn ON rn.package_id = e.package_id
          WHERE p.id = e.package_id
          RETURNING p.id
        ),
@@ -93,14 +93,15 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
          SELECT s.id AS package_id, f.field
          FROM snap s
          JOIN ${STAGING_SCHEMA}.enrich_packages e ON e.package_id = s.id
-         LEFT JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
+         LEFT JOIN ${STAGING_SCHEMA}.repo_choice rn ON rn.package_id = e.package_id
          CROSS JOIN LATERAL (VALUES
            ('packages.status',                  s.status                  IS DISTINCT FROM e.status),
            ('packages.description',             s.description             IS DISTINCT FROM COALESCE(e.description, s.description)),
            ('packages.homepage',                s.homepage                IS DISTINCT FROM COALESCE(e.homepage, s.homepage)),
            ('packages.declared_repository_url', s.declared_repository_url IS DISTINCT FROM COALESCE(e.declared_repository_url, s.declared_repository_url)),
            ('packages.repository_url',          s.repository_url          IS DISTINCT FROM
-               CASE WHEN e.declared_repository_url IS NOT NULL THEN rn.repository_url ELSE s.repository_url END),
+               CASE WHEN e.declared_repository_url IS NOT NULL OR rn.repository_url IS NOT NULL
+                    THEN rn.repository_url ELSE s.repository_url END),
            ('packages.licenses',                s.licenses                IS DISTINCT FROM COALESCE(e.licenses, s.licenses)),
            ('packages.licenses_raw',            s.licenses_raw            IS DISTINCT FROM COALESCE(e.licenses_raw, s.licenses_raw)),
            ('packages.keywords',                s.keywords                IS DISTINCT FROM COALESCE(e.keywords, s.keywords)),
@@ -176,25 +177,24 @@ export async function enrichVersions(qx: QueryExecutor): Promise<EnrichVersionsR
 }
 
 // Writes only url + host — other repo fields belong to the GitHub enricher. Uses
-// repo_norm (built by normalizeRepos) so repos.url/package_repos always agree with
+// repo_choice (built by normalizeRepos) so repos.url/package_repos always agree with
 // the canonical packages.repository_url — never the raw declared_repository_url.
 export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult> {
   return withTunedSession(qx, 'repos', async (tx) => {
     const repoRow = await tx.selectOne(
       `WITH new_repos AS (
          INSERT INTO repos (url, host, updated_at)
-         SELECT DISTINCT rn.repository_url, rn.host, NOW()
-         FROM ${STAGING_SCHEMA}.enrich_packages e
-         JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
+         SELECT DISTINCT rc.repository_url, rc.host, NOW()
+         FROM ${STAGING_SCHEMA}.repo_choice rc
+         WHERE rc.repository_url IS NOT NULL
          ON CONFLICT (url) DO NOTHING
          RETURNING url
        ),
        ins_audit AS (
          INSERT INTO ${STAGING_SCHEMA}.audit_changes (package_id, field)
-         SELECT e.package_id, f.field
-         FROM ${STAGING_SCHEMA}.enrich_packages e
-         JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
-         JOIN new_repos nr ON nr.url = rn.repository_url
+         SELECT rc.package_id, f.field
+         FROM ${STAGING_SCHEMA}.repo_choice rc
+         JOIN new_repos nr ON nr.url = rc.repository_url
          CROSS JOIN LATERAL (VALUES ('repos.url'), ('repos.host')) AS f(field)
          RETURNING 1
        )
@@ -212,10 +212,9 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
     // repos ⋈ package_repos, not packages.repository_url) would keep reading it.
     const pruneRow = await tx.selectOne(
       `WITH targets AS (
-         SELECT e.package_id, r.id AS repo_id
-         FROM ${STAGING_SCHEMA}.enrich_packages e
-         LEFT JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
-         LEFT JOIN repos r ON r.url = rn.repository_url
+         SELECT rc.package_id, r.id AS repo_id
+         FROM ${STAGING_SCHEMA}.repo_choice rc
+         LEFT JOIN repos r ON r.url = rc.repository_url
        ),
        del AS (
          DELETE FROM package_repos pr
@@ -241,7 +240,7 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
          SELECT pr.package_id, pr.repo_id, pr.source, pr.confidence
          FROM package_repos pr
          WHERE pr.package_id IN (
-           SELECT package_id FROM ${STAGING_SCHEMA}.enrich_packages WHERE declared_repository_url IS NOT NULL
+           SELECT package_id FROM ${STAGING_SCHEMA}.repo_choice WHERE repository_url IS NOT NULL
          )
        ),
        ins AS (
@@ -249,12 +248,11 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
            package_id, repo_id, source, signal, ownership_match, provenance,
            confidence, created_at, verified_at
          )
-         SELECT e.package_id, r.id, $(source), 'primary', 'no_evidence', NULL,
+         SELECT rc.package_id, r.id, $(source), rc.signal, 'no_evidence', NULL,
                 s.confidence, NOW(), NOW()
-         FROM ${STAGING_SCHEMA}.enrich_packages e
-         JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
-         JOIN repos r ON r.url = rn.repository_url
-         JOIN packages p ON p.id = e.package_id
+         FROM ${STAGING_SCHEMA}.repo_choice rc
+         JOIN repos r ON r.url = rc.repository_url
+         JOIN packages p ON p.id = rc.package_id
          CROSS JOIN LATERAL (SELECT ${CARGO_CONFIDENCE} AS confidence) s
          ON CONFLICT (package_id, repo_id) DO UPDATE SET
            source           = CASE WHEN EXCLUDED.source = package_repos.source OR EXCLUDED.confidence > package_repos.confidence

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -70,8 +70,7 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            description             = COALESCE(e.description, p.description),
            homepage                = COALESCE(e.homepage, p.homepage),
            declared_repository_url = COALESCE(e.declared_repository_url, p.declared_repository_url),
-           repository_url          = CASE WHEN e.declared_repository_url IS NOT NULL OR rn.repository_url IS NOT NULL
-                                          THEN rn.repository_url ELSE p.repository_url END,
+           repository_url          = rn.repository_url,
            licenses                = COALESCE(e.licenses, p.licenses),
            licenses_raw            = COALESCE(e.licenses_raw, p.licenses_raw),
            keywords                = COALESCE(e.keywords, p.keywords),
@@ -99,9 +98,7 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            ('packages.description',             s.description             IS DISTINCT FROM COALESCE(e.description, s.description)),
            ('packages.homepage',                s.homepage                IS DISTINCT FROM COALESCE(e.homepage, s.homepage)),
            ('packages.declared_repository_url', s.declared_repository_url IS DISTINCT FROM COALESCE(e.declared_repository_url, s.declared_repository_url)),
-           ('packages.repository_url',          s.repository_url          IS DISTINCT FROM
-               CASE WHEN e.declared_repository_url IS NOT NULL OR rn.repository_url IS NOT NULL
-                    THEN rn.repository_url ELSE s.repository_url END),
+           ('packages.repository_url',          s.repository_url          IS DISTINCT FROM rn.repository_url),
            ('packages.licenses',                s.licenses                IS DISTINCT FROM COALESCE(e.licenses, s.licenses)),
            ('packages.licenses_raw',            s.licenses_raw            IS DISTINCT FROM COALESCE(e.licenses_raw, s.licenses_raw)),
            ('packages.keywords',                s.keywords                IS DISTINCT FROM COALESCE(e.keywords, s.keywords)),

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -70,7 +70,8 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            description             = COALESCE(e.description, p.description),
            homepage                = COALESCE(e.homepage, p.homepage),
            declared_repository_url = COALESCE(e.declared_repository_url, p.declared_repository_url),
-           repository_url          = rn.repository_url,
+           repository_url          = CASE WHEN e.declared_repository_url IS NOT NULL OR rn.repository_url IS NOT NULL
+                                         THEN rn.repository_url ELSE p.repository_url END,
            licenses                = COALESCE(e.licenses, p.licenses),
            licenses_raw            = COALESCE(e.licenses_raw, p.licenses_raw),
            keywords                = COALESCE(e.keywords, p.keywords),
@@ -98,7 +99,9 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            ('packages.description',             s.description             IS DISTINCT FROM COALESCE(e.description, s.description)),
            ('packages.homepage',                s.homepage                IS DISTINCT FROM COALESCE(e.homepage, s.homepage)),
            ('packages.declared_repository_url', s.declared_repository_url IS DISTINCT FROM COALESCE(e.declared_repository_url, s.declared_repository_url)),
-           ('packages.repository_url',          s.repository_url          IS DISTINCT FROM rn.repository_url),
+           ('packages.repository_url',          s.repository_url IS DISTINCT FROM
+              CASE WHEN e.declared_repository_url IS NOT NULL OR rn.repository_url IS NOT NULL
+                   THEN rn.repository_url ELSE s.repository_url END),
            ('packages.licenses',                s.licenses                IS DISTINCT FROM COALESCE(e.licenses, s.licenses)),
            ('packages.licenses_raw',            s.licenses_raw            IS DISTINCT FROM COALESCE(e.licenses_raw, s.licenses_raw)),
            ('packages.keywords',                s.keywords                IS DISTINCT FROM COALESCE(e.keywords, s.keywords)),

--- a/services/apps/packages_worker/src/cargo/normalizeRepos.ts
+++ b/services/apps/packages_worker/src/cargo/normalizeRepos.ts
@@ -11,29 +11,6 @@ const log = getServiceChildLogger('cargo-normalize')
 // Batch size for the mapping upsert — keeps parameter arrays well under Postgres limits.
 const INSERT_BATCH = 5000
 
-/**
- * Builds `cargo_sync.repo_norm(declared, repository_url, host)`, mapping every
- * distinct `declared_repository_url` and `homepage` staged in `enrich_packages` to its canonical
- * `https://<host>/<owner>/<name>` form via the shared `canonicalizeRepoUrl`
- * (same normalizer npm/pypi use — no per-ecosystem fork).
- *
- * Only inputs `canonicalizeRepoUrl` can reduce to an owner/name pair are stored;
- * unparseable URLs or those with fewer than two path segments are omitted, so a
- * LEFT JOIN from `enrich_packages` yields NULL — that both recovers derivable
- * URLs (Gap A) and clears that class of junk from `packages.repository_url`
- * (Gap C). Note this does not validate that the result is an actual repository
- * host — a URL-shaped homepage with ≥2 path segments (e.g.
- * `https://example.com/owner/repo`) still canonicalizes and is stored.
- *
- * `cargo_sync.repo_choice` then picks one repo per crate: the declared `repository`
- * field (`primary`) or, when that is absent or unparseable, the `homepage` — accepted
- * only on a recognized VCS host, since a homepage is free-form. `documentation` is not
- * staged from the dump and is almost always docs.rs, which that gate rejects anyway.
- *
- * Normalization runs in TypeScript because the bulk set-based cargo pipeline
- * cannot call the parser per row; the resulting mapping table lets the SQL
- * enrich phases join back to it. Idempotent: the table is rebuilt each run.
- */
 export async function normalizeRepos(qx: QueryExecutor): Promise<NormalizeReposResult> {
   const rows: Array<{ url: string }> = await qx.select(
     `SELECT DISTINCT declared_repository_url AS url

--- a/services/apps/packages_worker/src/cargo/normalizeRepos.ts
+++ b/services/apps/packages_worker/src/cargo/normalizeRepos.ts
@@ -13,7 +13,7 @@ const INSERT_BATCH = 5000
 
 /**
  * Builds `cargo_sync.repo_norm(declared, repository_url, host)`, mapping every
- * distinct `declared_repository_url` staged in `enrich_packages` to its canonical
+ * distinct `declared_repository_url` and `homepage` staged in `enrich_packages` to its canonical
  * `https://<host>/<owner>/<name>` form via the shared `canonicalizeRepoUrl`
  * (same normalizer npm/pypi use — no per-ecosystem fork).
  *
@@ -25,15 +25,24 @@ const INSERT_BATCH = 5000
  * host — a URL-shaped homepage with ≥2 path segments (e.g.
  * `https://example.com/owner/repo`) still canonicalizes and is stored.
  *
+ * `cargo_sync.repo_choice` then picks one repo per crate: the declared `repository`
+ * field (`primary`) or, when that is absent or unparseable, the `homepage` — accepted
+ * only on a recognized VCS host, since a homepage is free-form. `documentation` is not
+ * staged from the dump and is almost always docs.rs, which that gate rejects anyway.
+ *
  * Normalization runs in TypeScript because the bulk set-based cargo pipeline
  * cannot call the parser per row; the resulting mapping table lets the SQL
  * enrich phases join back to it. Idempotent: the table is rebuilt each run.
  */
 export async function normalizeRepos(qx: QueryExecutor): Promise<NormalizeReposResult> {
-  const rows: Array<{ declared_repository_url: string }> = await qx.select(
-    `SELECT DISTINCT declared_repository_url
+  const rows: Array<{ url: string }> = await qx.select(
+    `SELECT DISTINCT declared_repository_url AS url
        FROM ${STAGING_SCHEMA}.enrich_packages
-      WHERE declared_repository_url IS NOT NULL`,
+      WHERE declared_repository_url IS NOT NULL
+     UNION
+     SELECT DISTINCT homepage AS url
+       FROM ${STAGING_SCHEMA}.enrich_packages
+      WHERE homepage IS NOT NULL`,
   )
 
   await qx.result(
@@ -46,9 +55,9 @@ export async function normalizeRepos(qx: QueryExecutor): Promise<NormalizeReposR
   )
 
   const mapped = rows
-    .map(({ declared_repository_url }) => ({
-      declared: declared_repository_url,
-      canonical: canonicalizeRepoUrl(declared_repository_url),
+    .map(({ url }) => ({
+      declared: url,
+      canonical: canonicalizeRepoUrl(url),
     }))
     .filter((r): r is { declared: string; canonical: CanonicalRepo } => r.canonical !== null)
 
@@ -66,7 +75,29 @@ export async function normalizeRepos(qx: QueryExecutor): Promise<NormalizeReposR
     )
   }
 
-  const result: NormalizeReposResult = { scanned: rows.length, normalized: mapped.length }
+  await qx.result(
+    `DROP TABLE IF EXISTS ${STAGING_SCHEMA}.repo_choice CASCADE;
+     CREATE TABLE ${STAGING_SCHEMA}.repo_choice AS
+     SELECT e.package_id,
+            COALESCE(rd.repository_url, rh.repository_url) AS repository_url,
+            COALESCE(rd.host, rh.host)                     AS host,
+            CASE WHEN rd.repository_url IS NOT NULL THEN 'primary' ELSE 'secondary' END AS signal
+     FROM ${STAGING_SCHEMA}.enrich_packages e
+     LEFT JOIN ${STAGING_SCHEMA}.repo_norm rd ON rd.declared = e.declared_repository_url
+     LEFT JOIN ${STAGING_SCHEMA}.repo_norm rh ON rh.declared = e.homepage AND rh.host <> 'other';
+     CREATE INDEX ON ${STAGING_SCHEMA}.repo_choice (package_id)`,
+  )
+
+  const choiceRow = await qx.selectOne(
+    `SELECT COUNT(*) FILTER (WHERE repository_url IS NOT NULL AND signal = 'secondary')::int AS fallbacks
+       FROM ${STAGING_SCHEMA}.repo_choice`,
+  )
+
+  const result: NormalizeReposResult = {
+    scanned: rows.length,
+    normalized: mapped.length,
+    homepageFallbacks: choiceRow.fallbacks,
+  }
   log.info(result, 'cargo repo normalization complete')
   return result
 }

--- a/services/apps/packages_worker/src/cargo/types.ts
+++ b/services/apps/packages_worker/src/cargo/types.ts
@@ -15,6 +15,7 @@ export interface LoadResult {
 export interface NormalizeReposResult {
   scanned: number
   normalized: number
+  homepageFallbacks: number
 }
 
 export interface EnrichPackagesResult {

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -4,6 +4,7 @@ import {
   listMavenCriticalPackagesById,
   listMavenPackagesToSync,
   logAuditFieldChange,
+  removeDeclaredPackageRepo,
   replacePackageMaintainers,
   touchPackageSyncedAt,
   upsertMaintainer,
@@ -57,12 +58,22 @@ type PackageRow = MavenPackageToSync
 
 // prettier-ignore
 export async function writeRepoLink(qx: QueryExecutor, packageId: number, repositoryUrl: string | null, changed?: Set<string>, signal: PackageRepoSignal = 'primary'): Promise<void> {
-  if (!repositoryUrl) return
+  if (!repositoryUrl) {
+    const removedFields = await removeDeclaredPackageRepo(qx, String(packageId))
+    removedFields.forEach((f) => changed?.add(f))
+    return
+  }
   const parsed = parseRepoUrl(repositoryUrl)
-  if (!parsed) return
+  if (!parsed) {
+    const removedFields = await removeDeclaredPackageRepo(qx, String(packageId))
+    removedFields.forEach((f) => changed?.add(f))
+    return
+  }
   const repoId = await upsertRepo(qx, { url: repositoryUrl, ...parsed })
   const repoChanged = await upsertPackageRepo(qx, String(packageId), String(repoId), { source: 'declared', signal })
   repoChanged.forEach((f) => changed?.add(f))
+  const removedFields = await removeDeclaredPackageRepo(qx, String(packageId), String(repoId))
+  removedFields.forEach((f) => changed?.add(f))
 }
 
 // Postgres deadlock (40P01) is transient: concurrent transactions upserting the same shared

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -12,9 +12,11 @@ import {
   upsertRepo,
   upsertVersionsBatch,
 } from '@crowd/data-access-layer'
+import type { PackageRepoSignal } from '@crowd/data-access-layer/src/packages/repoConfidence'
 import { getServiceChildLogger } from '@crowd/logging'
 
 import { getMavenConfig } from '../config'
+import { resolveManifestRepo } from '../utils/resolveManifestRepo'
 
 import { extractArtifact, getPomCacheStats, normalizeScmUrl } from './extract'
 import { isMavenFetchError, resolveVersionsList } from './metadata'
@@ -54,12 +56,12 @@ type PackageRow = MavenPackageToSync
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 // prettier-ignore
-export async function writeRepoLink(qx: QueryExecutor, packageId: number, repositoryUrl: string | null, changed?: Set<string>): Promise<void> {
+export async function writeRepoLink(qx: QueryExecutor, packageId: number, repositoryUrl: string | null, changed?: Set<string>, signal: PackageRepoSignal = 'primary'): Promise<void> {
   if (!repositoryUrl) return
   const parsed = parseRepoUrl(repositoryUrl)
   if (!parsed) return
   const repoId = await upsertRepo(qx, { url: repositoryUrl, ...parsed })
-  const repoChanged = await upsertPackageRepo(qx, String(packageId), String(repoId), { source: 'declared' })
+  const repoChanged = await upsertPackageRepo(qx, String(packageId), String(repoId), { source: 'declared', signal })
   repoChanged.forEach((f) => changed?.add(f))
 }
 
@@ -261,7 +263,11 @@ async function processCriticalPackage(qx: QueryExecutor, pkg: PackageRow, forceF
     return { status: 'error' }
   }
 
-  const repositoryUrl = normalizeScmUrl(result.scmUrl)
+  const scmRepositoryUrl = normalizeScmUrl(result.scmUrl)
+  const fallbackRepo = scmRepositoryUrl
+    ? null
+    : resolveManifestRepo([{ field: 'url', url: result.homepageUrl, signal: 'secondary' }])
+  const repositoryUrl = scmRepositoryUrl ?? fallbackRepo?.repo.url ?? null
 
   await withDeadlockRetry(() =>
     qx.tx(async (t: QueryExecutor) => {
@@ -335,7 +341,7 @@ async function processCriticalPackage(qx: QueryExecutor, pkg: PackageRow, forceF
         pmChanged.forEach((f) => changed.add(f))
       }
 
-      await writeRepoLink(t, packageId, repositoryUrl, changed)
+      await writeRepoLink(t, packageId, repositoryUrl, changed, fallbackRepo ? 'secondary' : 'primary')
 
       await logAuditFieldChange(t, 'maven', pkg.purl, Array.from(changed))
 

--- a/services/apps/packages_worker/src/npm/normalize.ts
+++ b/services/apps/packages_worker/src/npm/normalize.ts
@@ -1,5 +1,4 @@
-import { canonicalizeRepoUrl } from '../utils/canonicalizeRepoUrl'
-import type { CanonicalRepo } from '../utils/canonicalizeRepoUrl'
+import { ResolvedManifestRepo, resolveManifestRepo } from '../utils/resolveManifestRepo'
 
 import type { Packument } from './types'
 
@@ -70,12 +69,24 @@ function dedup(arr: string[]): string[] {
   return [...new Set(arr)]
 }
 
-export function extractRepo(packument: Packument): CanonicalRepo | null {
+export function npmRepositoryField(packument: Packument): string | null {
   const repo = packument.repository
   if (!repo) return null
-  const raw = typeof repo === 'string' ? repo : repo.url
-  if (!raw) return null
-  return canonicalizeRepoUrl(raw)
+  return (typeof repo === 'string' ? repo : repo.url) || null
+}
+
+function npmBugsUrl(packument: Packument): string | null {
+  const bugs = packument.bugs
+  if (!bugs) return null
+  return (typeof bugs === 'string' ? bugs : bugs.url) || null
+}
+
+export function resolveNpmRepo(packument: Packument): ResolvedManifestRepo | null {
+  return resolveManifestRepo([
+    { field: 'repository', url: npmRepositoryField(packument) },
+    { field: 'homepage', url: packument.homepage },
+    { field: 'bugs.url', url: npmBugsUrl(packument) },
+  ])
 }
 
 export function collectMaintainers(packument: Packument): Array<{

--- a/services/apps/packages_worker/src/npm/types.ts
+++ b/services/apps/packages_worker/src/npm/types.ts
@@ -16,6 +16,7 @@ export interface Packument {
   license?: string | { type: string; url?: string }
   licenses?: Array<{ type: string; url?: string }>
   repository?: string | { type?: string; url: string; directory?: string }
+  bugs?: string | { url?: string; email?: string }
   author?: string | { name: string; email?: string; url?: string }
   maintainers?: Array<{ name: string; email?: string }>
   'dist-tags': Record<string, string>

--- a/services/apps/packages_worker/src/npm/upsertPackage.ts
+++ b/services/apps/packages_worker/src/npm/upsertPackage.ts
@@ -1,5 +1,6 @@
 import {
   getOrCreateRepoByUrl,
+  removeDeclaredPackageRepo,
   upsertNpmFundingLinks,
   upsertNpmPackage,
   upsertNpmVersions,
@@ -94,6 +95,12 @@ export async function upsertPackage(
         signal: resolvedRepo.signal,
       })
       linkChanged.forEach((f) => changed.add(f))
+
+      const removedFields = await removeDeclaredPackageRepo(t, pkgId, repoId)
+      removedFields.forEach((f) => changed.add(f))
+    } else {
+      const removedFields = await removeDeclaredPackageRepo(t, pkgId)
+      removedFields.forEach((f) => changed.add(f))
     }
 
     const verChanged = await upsertNpmVersions(

--- a/services/apps/packages_worker/src/npm/upsertPackage.ts
+++ b/services/apps/packages_worker/src/npm/upsertPackage.ts
@@ -12,10 +12,11 @@ import { stripNullBytesDeep } from '../utils/stripNullBytesDeep'
 
 import {
   collectMaintainers,
-  extractRepo,
   isPrerelease,
   normalizeLicenses,
+  npmRepositoryField,
   parseNpmName,
+  resolveNpmRepo,
   versionLicense,
 } from './normalize'
 import type { FundingEntry, Packument } from './types'
@@ -36,9 +37,9 @@ export async function upsertPackage(
   const { namespace, name } = parseNpmName(raw)
   const licenses = normalizeLicenses(packument)
   const licensesRaw = typeof packument.license === 'string' ? packument.license : null
-  const declaredRepositoryUrl = rawRepoUrl(packument)
-  const repo = extractRepo(packument)
-  const repositoryUrl = repo?.url ?? null
+  const declaredRepositoryUrl = npmRepositoryField(packument)
+  const resolvedRepo = resolveNpmRepo(packument)
+  const repositoryUrl = resolvedRepo?.repo.url ?? null
   const versionEntries = Object.entries(packument.versions)
   const time = packument.time ?? {}
   const latestVersion = packument['dist-tags']?.latest ?? null
@@ -80,15 +81,18 @@ export async function upsertPackage(
     })
     pkgChanged.forEach((f) => changed.add(f))
 
-    if (repo) {
+    if (resolvedRepo) {
       const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(
         t,
-        repo.url,
-        repo.host,
+        resolvedRepo.repo.url,
+        resolvedRepo.repo.host,
       )
       repoChanged.forEach((f) => changed.add(f))
 
-      const linkChanged = await upsertPackageRepo(t, pkgId, repoId, { source: 'declared' })
+      const linkChanged = await upsertPackageRepo(t, pkgId, repoId, {
+        source: 'declared',
+        signal: resolvedRepo.signal,
+      })
       linkChanged.forEach((f) => changed.add(f))
     }
 
@@ -117,12 +121,6 @@ export async function upsertPackage(
   })
 
   return { purl, changedFields: Array.from(changed) }
-}
-
-function rawRepoUrl(packument: Packument): string | null {
-  const repo = packument.repository
-  if (!repo) return null
-  return typeof repo === 'string' ? repo || null : repo.url || null
 }
 
 function extractFundingLinks(

--- a/services/apps/packages_worker/src/nuget/normalize.ts
+++ b/services/apps/packages_worker/src/nuget/normalize.ts
@@ -1,6 +1,6 @@
 import { XMLParser } from 'fast-xml-parser'
 
-import { canonicalizeRepoUrl } from '../utils/canonicalizeRepoUrl'
+import { resolveManifestRepo } from '../utils/resolveManifestRepo'
 
 import {
   NormalizedNuGetPackage,
@@ -39,17 +39,6 @@ export function parseNuspecRepositoryUrl(nuspecXml: string): string | null {
     return typeof url === 'string' && url.trim() !== '' ? url.trim() : null
   } catch {
     return null
-  }
-}
-
-const SCM_HOSTS = ['github.com', 'gitlab.com', 'bitbucket.org']
-
-function isScmUrl(url: string | undefined): boolean {
-  if (!url) return false
-  try {
-    return SCM_HOSTS.some((h) => new URL(url).hostname.endsWith(h))
-  } catch {
-    return false
   }
 }
 
@@ -95,7 +84,6 @@ export function normalizeNuGetPackage(
   const homepage = searchResult?.projectUrl || latestListedEntry?.projectUrl || null
 
   // Scan all entries (prefer latest listed, then any) for a nuspec <repository> url.
-  // Fall back to a SCM-shaped projectUrl/homepage when no nuspec repository is present.
   const entriesForRepo = latestListedEntry
     ? [
         latestListedEntry,
@@ -107,9 +95,10 @@ export function normalizeNuGetPackage(
   const fetchedNuspecRepoUrl = nuspecXml ? parseNuspecRepositoryUrl(nuspecXml) : null
   const nuspecRepoUrl = fetchedNuspecRepoUrl ?? catalogRepoUrl
   const declaredRepositoryUrl = nuspecRepoUrl ?? null
-  const repo =
-    (nuspecRepoUrl ? canonicalizeRepoUrl(nuspecRepoUrl) : null) ??
-    (isScmUrl(homepage) ? canonicalizeRepoUrl(homepage) : null)
+  const resolvedRepo = resolveManifestRepo([
+    { field: 'repository', url: nuspecRepoUrl },
+    { field: 'projectUrl', url: homepage },
+  ])
 
   const keywords = searchResult?.tags && searchResult.tags.length > 0 ? searchResult.tags : null
 
@@ -164,7 +153,7 @@ export function normalizeNuGetPackage(
     description,
     homepage: homepage || null,
     declaredRepositoryUrl,
-    repo,
+    resolvedRepo,
     licenses,
     licensesRaw,
     keywords,

--- a/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
@@ -7,6 +7,7 @@ import {
   logAuditFieldChange,
   markNuGetPackageError,
   recordNuGetDownloadSnapshot,
+  removeDeclaredPackageRepo,
   replacePackageMaintainers,
   upsertMaintainer,
   upsertNuGetPackage,
@@ -145,6 +146,12 @@ async function processPackage(
           signal: normalized.resolvedRepo.signal,
         })
         linkChanged.forEach((f) => changed.add(f))
+
+        const removedFields = await removeDeclaredPackageRepo(t, packageDbId.toString(), repoId)
+        removedFields.forEach((f) => changed.add(f))
+      } else {
+        const removedFields = await removeDeclaredPackageRepo(t, packageDbId.toString())
+        removedFields.forEach((f) => changed.add(f))
       }
 
       if (normalized.versions.length > 0) {

--- a/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
@@ -118,7 +118,7 @@ async function processPackage(
         description: normalized.description,
         homepage: normalized.homepage,
         declaredRepositoryUrl: normalized.declaredRepositoryUrl,
-        repositoryUrl: normalized.repo?.url ?? null,
+        repositoryUrl: normalized.resolvedRepo?.repo.url ?? null,
         licenses: normalized.licenses,
         licensesRaw: normalized.licensesRaw,
         keywords: normalized.keywords,
@@ -132,16 +132,17 @@ async function processPackage(
       })
       pkgChanged.forEach((f) => changed.add(f))
 
-      if (normalized.repo) {
+      if (normalized.resolvedRepo) {
         const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(
           t,
-          normalized.repo.url,
-          normalized.repo.host,
+          normalized.resolvedRepo.repo.url,
+          normalized.resolvedRepo.repo.host,
         )
         repoChanged.forEach((f) => changed.add(f))
 
         const linkChanged = await upsertPackageRepo(t, packageDbId.toString(), repoId, {
           source: 'declared',
+          signal: normalized.resolvedRepo.signal,
         })
         linkChanged.forEach((f) => changed.add(f))
       }

--- a/services/apps/packages_worker/src/nuget/types.ts
+++ b/services/apps/packages_worker/src/nuget/types.ts
@@ -1,4 +1,4 @@
-import { CanonicalRepo } from '../utils/canonicalizeRepoUrl'
+import { ResolvedManifestRepo } from '../utils/resolveManifestRepo'
 
 export interface NuGetConfig {
   batchSize: number
@@ -75,7 +75,7 @@ export interface NormalizedNuGetPackage {
   description: string | null
   homepage: string | null
   declaredRepositoryUrl: string | null
-  repo: CanonicalRepo | null
+  resolvedRepo: ResolvedManifestRepo | null
   licenses: string[] | null
   licensesRaw: string | null
   keywords: string[] | null

--- a/services/apps/packages_worker/src/packagist/__tests__/dueSelection.test.ts
+++ b/services/apps/packages_worker/src/packagist/__tests__/dueSelection.test.ts
@@ -225,6 +225,7 @@ describe('updatePackagistPackageStats', () => {
     qx.selectOneOrNone.mockResolvedValue({
       id: '7',
       is_critical: true,
+      homepage: null,
       changed_fields: ['packages.description'],
     })
 
@@ -241,6 +242,7 @@ describe('updatePackagistPackageStats', () => {
     expect(result).toEqual({
       id: '7',
       isCritical: true,
+      homepage: null,
       changedFields: ['packages.description'],
     })
   })

--- a/services/apps/packages_worker/src/packagist/__tests__/persistPackageInfo.test.ts
+++ b/services/apps/packages_worker/src/packagist/__tests__/persistPackageInfo.test.ts
@@ -57,6 +57,7 @@ describe('persistPackagistPackageInfo', () => {
     mockUpdate.mockResolvedValue({
       id: '7',
       isCritical: true,
+      homepage: null,
       changedFields: ['packages.description'],
     })
     mockMaintainers.mockResolvedValue(['maintainers.display_name'])
@@ -78,7 +79,10 @@ describe('persistPackagistPackageInfo', () => {
     expect(mockUpdate.mock.calls[0][1]).not.toHaveProperty('downloadsLast30d')
     // canonicalized (lowercased) url + coarse host, linked with the manifest-declared convention
     expect(mockRepoGet).toHaveBeenCalledWith(qx, 'https://github.com/seldaek/monolog', 'github')
-    expect(mockRepoLink).toHaveBeenCalledWith(qx, '7', '55', { source: 'declared' })
+    expect(mockRepoLink).toHaveBeenCalledWith(qx, '7', '55', {
+      source: 'declared',
+      signal: 'primary',
+    })
     // any stale 'declared' link pointing at a different repo is pruned in the same pass
     expect(mockRepoRemove).toHaveBeenCalledWith(qx, '7', '55')
     expect(mockMaintainers).toHaveBeenCalledWith(qx, '7', stats.maintainers, 'packagist')
@@ -96,30 +100,36 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('skips maintainers for a non-critical package but still links the repo', async () => {
-    mockUpdate.mockResolvedValue({ id: '8', isCritical: false, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '8', isCritical: false, homepage: null, changedFields: [] })
 
     await persistPackagistPackageInfo(qx, PURL, stats)
 
     expect(mockMaintainers).not.toHaveBeenCalled()
     expect(mockRepoGet).toHaveBeenCalledWith(qx, 'https://github.com/seldaek/monolog', 'github')
-    expect(mockRepoLink).toHaveBeenCalledWith(qx, '8', '55', { source: 'declared' })
+    expect(mockRepoLink).toHaveBeenCalledWith(qx, '8', '55', {
+      source: 'declared',
+      signal: 'primary',
+    })
   })
 
   it('prunes a stale declared link when the repository URL switches to a different repo', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: false, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: false, homepage: null, changedFields: [] })
     mockRepoGet.mockResolvedValue({ id: '99', changedFields: [] })
     mockRepoRemove.mockResolvedValue(['package_repos.repo_id'])
 
     const result = await persistPackagistPackageInfo(qx, PURL, stats)
 
-    expect(mockRepoLink).toHaveBeenCalledWith(qx, '7', '99', { source: 'declared' })
+    expect(mockRepoLink).toHaveBeenCalledWith(qx, '7', '99', {
+      source: 'declared',
+      signal: 'primary',
+    })
     // old link (some other repo_id) removed, new one (99) kept
     expect(mockRepoRemove).toHaveBeenCalledWith(qx, '7', '99')
     expect(result.changedFields).toContain('package_repos.repo_id')
   })
 
   it('reconciles a maintainer list that dropped to empty for a critical package', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, homepage: null, changedFields: [] })
     mockMaintainers.mockResolvedValue(['package_maintainers.maintainer_id'])
 
     const result = await persistPackagistPackageInfo(qx, PURL, { ...stats, maintainers: [] })
@@ -131,7 +141,7 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('skips the repo link and clears any previously-declared one when there is no repository URL', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, homepage: null, changedFields: [] })
     mockRepoRemove.mockResolvedValue(['package_repos.repo_id'])
 
     const result = await persistPackagistPackageInfo(qx, PURL, { ...stats, repositoryUrl: null })
@@ -143,8 +153,40 @@ describe('persistPackagistPackageInfo', () => {
     expect(result.changedFields).toContain('package_repos.repo_id')
   })
 
+  it('falls back to the stored homepage with a secondary signal when no repository URL is declared', async () => {
+    mockUpdate.mockResolvedValue({
+      id: '7',
+      isCritical: true,
+      homepage: 'https://github.com/Seldaek/monolog',
+      changedFields: [],
+    })
+
+    await persistPackagistPackageInfo(qx, PURL, { ...stats, repositoryUrl: null })
+
+    expect(mockRepoGet).toHaveBeenCalledWith(qx, 'https://github.com/seldaek/monolog', 'github')
+    expect(mockRepoLink).toHaveBeenCalledWith(qx, '7', '55', {
+      source: 'declared',
+      signal: 'secondary',
+    })
+  })
+
+  it('rejects a homepage fallback that is not on a recognized VCS host', async () => {
+    mockUpdate.mockResolvedValue({
+      id: '7',
+      isCritical: true,
+      homepage: 'https://monolog.example.com/docs/intro',
+      changedFields: [],
+    })
+
+    await persistPackagistPackageInfo(qx, PURL, { ...stats, repositoryUrl: null })
+
+    expect(mockRepoGet).not.toHaveBeenCalled()
+    expect(mockRepoLink).not.toHaveBeenCalled()
+    expect(mockRepoRemove).toHaveBeenCalledWith(qx, '7')
+  })
+
   it('skips the repo link and clears the stale one when the repository URL cannot be canonicalized', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, homepage: null, changedFields: [] })
 
     await persistPackagistPackageInfo(qx, PURL, { ...stats, repositoryUrl: 'not-a-valid-url' })
 
@@ -154,7 +196,7 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('does not trust a canonicalized host outside the SCM allowlist (wiki/issue-tracker/registry URLs)', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, homepage: null, changedFields: [] })
 
     await persistPackagistPackageInfo(qx, PURL, {
       ...stats,
@@ -173,6 +215,7 @@ describe('persistPackagistPackageInfo', () => {
     mockUpdate.mockResolvedValue({
       id: '7',
       isCritical: false,
+      homepage: null,
       changedFields: ['packages.description'],
     })
     mockRepoGet.mockResolvedValue({ id: '55', changedFields: ['repos.url', 'repos.host'] })
@@ -202,7 +245,7 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('strips NUL bytes from the description before writing (Postgres rejects them)', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: false, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: false, homepage: null, changedFields: [] })
 
     await persistPackagistPackageInfo(qx, PURL, {
       ...stats,

--- a/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
+++ b/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
@@ -9,6 +9,7 @@ import {
 import type { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
 import { canonicalizeRepoUrl } from '../utils/canonicalizeRepoUrl'
+import { resolveManifestRepo } from '../utils/resolveManifestRepo'
 import { stripNullBytesDeep } from '../utils/stripNullBytesDeep'
 
 import type { NormalizedPackagistStats } from './types'
@@ -31,13 +32,13 @@ export async function persistPackagistPackageInfo(
   // text columns reject; strip them before any field is persisted.
   stripNullBytesDeep(stats)
 
-  const canonical = stats.repositoryUrl ? canonicalizeRepoUrl(stats.repositoryUrl) : null
   // Packagist's repository field is free-form/author-supplied. canonicalizeRepoUrl's
   // 'other' bucket also matches non-repo URLs (wikis, issue trackers, registry pages)
   // that happen to have 2+ path segments, so only trust the verified SCM hosts here —
   // github.com/gitlab.com/bitbucket.org — rather than the shared utility's default,
   // which other callers (npm/maven/cargo) rely on staying permissive.
-  const trustedRepo = canonical && canonical.host !== 'other' ? canonical : null
+  const declared = stats.repositoryUrl ? canonicalizeRepoUrl(stats.repositoryUrl) : null
+  const primaryRepo = declared && declared.host !== 'other' ? declared : null
 
   let found = false
   const changedFields: string[] = []
@@ -48,7 +49,7 @@ export async function persistPackagistPackageInfo(
       purl,
       description: stats.description,
       declaredRepositoryUrl: stats.repositoryUrl,
-      repositoryUrl: trustedRepo?.url ?? null,
+      repositoryUrl: primaryRepo?.url ?? null,
       status: stats.status,
       totalDownloads: stats.downloadsTotal,
       dependentCount: stats.dependents,
@@ -60,14 +61,23 @@ export async function persistPackagistPackageInfo(
     const { id, isCritical } = result
     changedFields.push(...result.changedFields)
 
+    // The version manifests carry the homepage, not this endpoint — read back the one the
+    // metadata lane stored so a package that only declares a homepage still gets a link.
+    const resolvedRepo = primaryRepo
+      ? { repo: primaryRepo, signal: 'primary' as const }
+      : resolveManifestRepo([{ field: 'homepage', url: result.homepage, signal: 'secondary' }])
+
     // When there's no trusted repo (removed from the manifest, or no longer
     // canonicalizable to a known host), or it now resolves to a different repo, clear any
     // previously-declared link that no longer applies — package_repos' unique key is
     // (package_id, repo_id), not (package_id, source), so upserting the new link alone
     // would leave a stale one dangling.
-    if (trustedRepo) {
-      const repo = await getOrCreateRepoByUrl(t, trustedRepo.url, trustedRepo.host)
-      const linkChanged = await upsertPackageRepo(t, id, repo.id, { source: 'declared' })
+    if (resolvedRepo) {
+      const repo = await getOrCreateRepoByUrl(t, resolvedRepo.repo.url, resolvedRepo.repo.host)
+      const linkChanged = await upsertPackageRepo(t, id, repo.id, {
+        source: 'declared',
+        signal: resolvedRepo.signal,
+      })
       const removedFields = await removeDeclaredPackageRepo(t, id, repo.id)
       changedFields.push(...repo.changedFields, ...linkChanged, ...removedFields)
     } else {

--- a/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
+++ b/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
@@ -80,6 +80,15 @@ export async function persistPackagistPackageInfo(
       })
       const removedFields = await removeDeclaredPackageRepo(t, id, repo.id)
       changedFields.push(...repo.changedFields, ...linkChanged, ...removedFields)
+
+      if (resolvedRepo.signal === 'secondary') {
+        const repoUrlChanged = await t.result(
+          `UPDATE packages SET repository_url = $(url) WHERE id = $(id)::bigint
+             AND (repository_url IS DISTINCT FROM $(url))`,
+          { url: resolvedRepo.repo.url, id },
+        )
+        if (repoUrlChanged > 0) changedFields.push('packages.repository_url')
+      }
     } else {
       const removedFields = await removeDeclaredPackageRepo(t, id)
       changedFields.push(...removedFields)

--- a/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
+++ b/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
@@ -2,6 +2,7 @@ import {
   getOrCreateRepoByUrl,
   logAuditFieldChanges,
   removeDeclaredPackageRepo,
+  setPackageRepositoryUrl,
   updatePackagistPackageStats,
   upsertPackageMaintainers,
   upsertPackageRepo,
@@ -82,12 +83,7 @@ export async function persistPackagistPackageInfo(
       changedFields.push(...repo.changedFields, ...linkChanged, ...removedFields)
 
       if (resolvedRepo.signal === 'secondary') {
-        const repoUrlChanged = await t.result(
-          `UPDATE packages SET repository_url = $(url) WHERE id = $(id)::bigint
-             AND (repository_url IS DISTINCT FROM $(url))`,
-          { url: resolvedRepo.repo.url, id },
-        )
-        if (repoUrlChanged > 0) changedFields.push('packages.repository_url')
+        changedFields.push(...(await setPackageRepositoryUrl(t, id, resolvedRepo.repo.url)))
       }
     } else {
       const removedFields = await removeDeclaredPackageRepo(t, id)

--- a/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
@@ -247,6 +247,7 @@ describe('classifyProjectUrls', () => {
     )
     expect(r.homepage).toBe('https://flask.palletsprojects.com/')
     expect(r.declaredRepositoryUrl).toBe('https://github.com/pallets/flask/')
+    expect(r.declaredRepositoryField).toBe('source')
     expect(r.fundingLinks).toEqual([{ type: 'other', url: 'https://palletsprojects.com/donate' }])
   })
 
@@ -258,6 +259,28 @@ describe('classifyProjectUrls', () => {
   it('falls back to a repo-looking homepage when no explicit repo key', () => {
     const r = classifyProjectUrls({ Homepage: 'https://github.com/psf/requests' }, null)
     expect(r.declaredRepositoryUrl).toBe('https://github.com/psf/requests')
+    expect(r.declaredRepositoryField).toBe('homepage')
+  })
+
+  it('falls back to bug tracker URL when no explicit repo or homepage repo', () => {
+    const r = classifyProjectUrls(
+      { 'Bug Tracker': 'https://github.com/foo/bar/issues' },
+      null,
+    )
+    expect(r.declaredRepositoryUrl).toBe('https://github.com/foo/bar/issues')
+    expect(r.declaredRepositoryField).toBe('bug_tracker')
+  })
+
+  it('does not use bug tracker when an explicit repo key is present', () => {
+    const r = classifyProjectUrls(
+      {
+        Source: 'https://github.com/foo/bar',
+        'Bug Tracker': 'https://github.com/foo/bar/issues',
+      },
+      null,
+    )
+    expect(r.declaredRepositoryUrl).toBe('https://github.com/foo/bar')
+    expect(r.declaredRepositoryField).toBe('source')
   })
 
   it('infers funding type from the host', () => {

--- a/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
@@ -271,6 +271,14 @@ describe('classifyProjectUrls', () => {
     expect(r.declaredRepositoryField).toBe('bug_tracker')
   })
 
+  it('does not classify GitHub Issues URL as source via the git heuristic', () => {
+    const r = classifyProjectUrls(
+      { 'GitHub Issues': 'https://github.com/foo/bar/issues' },
+      null,
+    )
+    expect(r.declaredRepositoryField).toBe('bug_tracker')
+  })
+
   it('does not use bug tracker when an explicit repo key is present', () => {
     const r = classifyProjectUrls(
       {

--- a/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
@@ -276,7 +276,12 @@ describe('classifyProjectUrls', () => {
 
   it('returns nulls/empties when there are no urls', () => {
     const r = classifyProjectUrls(null, null)
-    expect(r).toEqual({ homepage: null, declaredRepositoryUrl: null, fundingLinks: [] })
+    expect(r).toEqual({
+      homepage: null,
+      declaredRepositoryUrl: null,
+      declaredRepositoryField: null,
+      fundingLinks: [],
+    })
   })
 })
 

--- a/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
@@ -263,19 +263,13 @@ describe('classifyProjectUrls', () => {
   })
 
   it('falls back to bug tracker URL when no explicit repo or homepage repo', () => {
-    const r = classifyProjectUrls(
-      { 'Bug Tracker': 'https://github.com/foo/bar/issues' },
-      null,
-    )
+    const r = classifyProjectUrls({ 'Bug Tracker': 'https://github.com/foo/bar/issues' }, null)
     expect(r.declaredRepositoryUrl).toBe('https://github.com/foo/bar/issues')
     expect(r.declaredRepositoryField).toBe('bug_tracker')
   })
 
   it('does not classify GitHub Issues URL as source via the git heuristic', () => {
-    const r = classifyProjectUrls(
-      { 'GitHub Issues': 'https://github.com/foo/bar/issues' },
-      null,
-    )
+    const r = classifyProjectUrls({ 'GitHub Issues': 'https://github.com/foo/bar/issues' }, null)
     expect(r.declaredRepositoryField).toBe('bug_tracker')
   })
 

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -184,6 +184,8 @@ export function collectPypiMaintainers(info: PyPiInfo): PypiPerson[] {
   return [...map.values()]
 }
 
+export type PypiRepositoryField = 'source' | 'homepage' | 'bug_tracker'
+
 export interface PypiFundingLink {
   type: string
   url: string
@@ -204,6 +206,7 @@ export function classifyProjectUrls(
 ): {
   homepage: string | null
   declaredRepositoryUrl: string | null
+  declaredRepositoryField: PypiRepositoryField | null
   fundingLinks: PypiFundingLink[]
 } {
   const entries = Object.entries(projectUrls ?? {}).map(
@@ -226,9 +229,18 @@ export function classifyProjectUrls(
     findByKey(/^code$/i) ??
     entries.find(([k, v]) => /source|repo|code|git/i.test(k) && REPO_HOST.test(v))?.[1] ??
     null
-  // Many projects only declare a Homepage that is itself the repo.
+  let declaredRepositoryField: PypiRepositoryField | null = declaredRepositoryUrl ? 'source' : null
+  // Many projects only declare a Homepage, or only a Bug Tracker, that is itself the repo.
   if (!declaredRepositoryUrl && homepage && REPO_HOST.test(homepage)) {
     declaredRepositoryUrl = homepage
+    declaredRepositoryField = 'homepage'
+  }
+  if (!declaredRepositoryUrl) {
+    const tracker = entries.find(([k, v]) => /bug|issue|tracker/i.test(k) && REPO_HOST.test(v))?.[1]
+    if (tracker) {
+      declaredRepositoryUrl = tracker
+      declaredRepositoryField = 'bug_tracker'
+    }
   }
 
   const seen = new Set<string>()
@@ -239,7 +251,7 @@ export function classifyProjectUrls(
     fundingLinks.push({ type: inferFundingType(v), url: v })
   }
 
-  return { homepage, declaredRepositoryUrl, fundingLinks }
+  return { homepage, declaredRepositoryUrl, declaredRepositoryField, fundingLinks }
 }
 
 export function parseKeywords(raw: string | null | undefined): string[] {

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -227,7 +227,10 @@ export function classifyProjectUrls(
     findByKey(/^repository$/i) ??
     findByKey(/^repo$/i) ??
     findByKey(/^code$/i) ??
-    entries.find(([k, v]) => /source|repo|code|\bgit\b/i.test(k) && REPO_HOST.test(v) && !/bug|issue|tracker/i.test(k))?.[1] ??
+    entries.find(
+      ([k, v]) =>
+        /source|repo|code|\bgit\b/i.test(k) && REPO_HOST.test(v) && !/bug|issue|tracker/i.test(k),
+    )?.[1] ??
     null
   let declaredRepositoryField: PypiRepositoryField | null = declaredRepositoryUrl ? 'source' : null
   // Many projects only declare a Homepage, or only a Bug Tracker, that is itself the repo.

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -227,7 +227,7 @@ export function classifyProjectUrls(
     findByKey(/^repository$/i) ??
     findByKey(/^repo$/i) ??
     findByKey(/^code$/i) ??
-    entries.find(([k, v]) => /source|repo|code|git/i.test(k) && REPO_HOST.test(v))?.[1] ??
+    entries.find(([k, v]) => /source|repo|code|\bgit\b/i.test(k) && REPO_HOST.test(v) && !/bug|issue|tracker/i.test(k))?.[1] ??
     null
   let declaredRepositoryField: PypiRepositoryField | null = declaredRepositoryUrl ? 'source' : null
   // Many projects only declare a Homepage, or only a Bug Tracker, that is itself the repo.

--- a/services/apps/packages_worker/src/pypi/upsertProject.ts
+++ b/services/apps/packages_worker/src/pypi/upsertProject.ts
@@ -6,6 +6,7 @@ import {
   upsertPypiPackage,
   upsertPypiVersions,
 } from '@crowd/data-access-layer/src/packages'
+import type { PackageRepoSignal } from '@crowd/data-access-layer/src/packages/repoConfidence'
 import type { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
 import { canonicalizeRepoUrl } from '../utils/canonicalizeRepoUrl'
@@ -37,11 +38,11 @@ export async function upsertProject(
     `https://pypi.org/project/${pypiName}/`
   const description = info.summary?.trim() ? info.summary.trim() : null
 
-  const { homepage, declaredRepositoryUrl, fundingLinks } = classifyProjectUrls(
-    info.project_urls,
-    info.home_page,
-  )
+  const { homepage, declaredRepositoryUrl, declaredRepositoryField, fundingLinks } =
+    classifyProjectUrls(info.project_urls, info.home_page)
   const repo = declaredRepositoryUrl ? canonicalizeRepoUrl(declaredRepositoryUrl) : null
+  const repoSignal: PackageRepoSignal =
+    declaredRepositoryField === 'source' ? 'primary' : 'secondary'
   const { licenses, licensesRaw } = resolvePypiLicenses(info)
   const keywords = parseKeywords(info.keywords)
   const maintainers = collectPypiMaintainers(info)
@@ -86,7 +87,10 @@ export async function upsertProject(
         repo.host,
       )
       repoChanged.forEach((f) => changed.add(f))
-      const linkChanged = await upsertPackageRepo(t, pkgId, repoId, { source: 'declared' })
+      const linkChanged = await upsertPackageRepo(t, pkgId, repoId, {
+        source: 'declared',
+        signal: repoSignal,
+      })
       linkChanged.forEach((f) => changed.add(f))
     }
 

--- a/services/apps/packages_worker/src/pypi/upsertProject.ts
+++ b/services/apps/packages_worker/src/pypi/upsertProject.ts
@@ -1,5 +1,6 @@
 import {
   getOrCreateRepoByUrl,
+  removeDeclaredPackageRepo,
   upsertNpmFundingLinks,
   upsertPackageMaintainers,
   upsertPackageRepo,
@@ -80,7 +81,7 @@ export async function upsertProject(
     })
     pkgChanged.forEach((f) => changed.add(f))
 
-    if (repo) {
+    if (repo && (repoSignal === 'primary' || repo.host !== 'other')) {
       const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(
         t,
         repo.url,
@@ -92,6 +93,12 @@ export async function upsertProject(
         signal: repoSignal,
       })
       linkChanged.forEach((f) => changed.add(f))
+
+      const removedFields = await removeDeclaredPackageRepo(t, pkgId, repoId)
+      removedFields.forEach((f) => changed.add(f))
+    } else {
+      const removedFields = await removeDeclaredPackageRepo(t, pkgId)
+      removedFields.forEach((f) => changed.add(f))
     }
 
     if (versionRows.length > 0) {

--- a/services/apps/packages_worker/src/pypi/upsertProject.ts
+++ b/services/apps/packages_worker/src/pypi/upsertProject.ts
@@ -41,7 +41,9 @@ export async function upsertProject(
 
   const { homepage, declaredRepositoryUrl, declaredRepositoryField, fundingLinks } =
     classifyProjectUrls(info.project_urls, info.home_page)
-  const repoCanonicalized = declaredRepositoryUrl ? canonicalizeRepoUrl(declaredRepositoryUrl) : null
+  const repoCanonicalized = declaredRepositoryUrl
+    ? canonicalizeRepoUrl(declaredRepositoryUrl)
+    : null
   const repoSignal: PackageRepoSignal =
     declaredRepositoryField === 'source' ? 'primary' : 'secondary'
   const repo =

--- a/services/apps/packages_worker/src/pypi/upsertProject.ts
+++ b/services/apps/packages_worker/src/pypi/upsertProject.ts
@@ -41,9 +41,13 @@ export async function upsertProject(
 
   const { homepage, declaredRepositoryUrl, declaredRepositoryField, fundingLinks } =
     classifyProjectUrls(info.project_urls, info.home_page)
-  const repo = declaredRepositoryUrl ? canonicalizeRepoUrl(declaredRepositoryUrl) : null
+  const repoCanonicalized = declaredRepositoryUrl ? canonicalizeRepoUrl(declaredRepositoryUrl) : null
   const repoSignal: PackageRepoSignal =
     declaredRepositoryField === 'source' ? 'primary' : 'secondary'
+  const repo =
+    repoCanonicalized && (repoSignal === 'primary' || repoCanonicalized.host !== 'other')
+      ? repoCanonicalized
+      : null
   const { licenses, licensesRaw } = resolvePypiLicenses(info)
   const keywords = parseKeywords(info.keywords)
   const maintainers = collectPypiMaintainers(info)
@@ -81,7 +85,7 @@ export async function upsertProject(
     })
     pkgChanged.forEach((f) => changed.add(f))
 
-    if (repo && (repoSignal === 'primary' || repo.host !== 'other')) {
+    if (repo) {
       const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(
         t,
         repo.url,

--- a/services/apps/packages_worker/src/rubygems/normalize.ts
+++ b/services/apps/packages_worker/src/rubygems/normalize.ts
@@ -1,4 +1,4 @@
-import { canonicalizeRepoUrl } from '../utils/canonicalizeRepoUrl'
+import { resolveManifestRepo } from '../utils/resolveManifestRepo'
 
 import {
   NormalizedRubyGemsOwner,
@@ -22,7 +22,11 @@ export function normalizeRubyGemsPackage(doc: RubyGemsGemResponse): NormalizedRu
     description: nonEmpty(doc.info),
     homepage: nonEmpty(doc.homepage_uri),
     declaredRepositoryUrl,
-    repo: declaredRepositoryUrl ? canonicalizeRepoUrl(declaredRepositoryUrl) : null,
+    resolvedRepo: resolveManifestRepo([
+      { field: 'source_code_uri', url: declaredRepositoryUrl },
+      { field: 'homepage_uri', url: doc.homepage_uri },
+      { field: 'bug_tracker_uri', url: doc.bug_tracker_uri },
+    ]),
     licenses,
     licensesRaw: licenses ? licenses.join(', ') : null,
     latestVersion: nonEmpty(doc.version),

--- a/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
+++ b/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
@@ -5,6 +5,7 @@ import {
   listRubyGemsPackagesToSync,
   logAuditFieldChange,
   recordDownloadSnapshot,
+  removeDeclaredPackageRepo,
   upsertPackage,
   upsertPackageRepo,
 } from '@crowd/data-access-layer'
@@ -131,6 +132,12 @@ async function processPackage(
           signal: normalized.resolvedRepo.signal,
         })
         linkChanged.forEach((f) => changed.add(f))
+
+        const removedFields = await removeDeclaredPackageRepo(t, packageDbId.toString(), repoId)
+        removedFields.forEach((f) => changed.add(f))
+      } else {
+        const removedFields = await removeDeclaredPackageRepo(t, packageDbId.toString())
+        removedFields.forEach((f) => changed.add(f))
       }
 
       if (normalized.totalDownloads > 0) {

--- a/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
+++ b/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
@@ -109,7 +109,7 @@ async function processPackage(
         description: normalized.description,
         homepage: normalized.homepage,
         declaredRepositoryUrl: normalized.declaredRepositoryUrl,
-        repositoryUrl: normalized.repo?.url ?? null,
+        repositoryUrl: normalized.resolvedRepo?.repo.url ?? null,
         licenses: normalized.licenses,
         licensesRaw: normalized.licensesRaw,
         latestVersion: normalized.latestVersion,
@@ -118,16 +118,17 @@ async function processPackage(
       })
       pkgChanged.forEach((f) => changed.add(f))
 
-      if (normalized.repo) {
+      if (normalized.resolvedRepo) {
         const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(
           t,
-          normalized.repo.url,
-          normalized.repo.host,
+          normalized.resolvedRepo.repo.url,
+          normalized.resolvedRepo.repo.host,
         )
         repoChanged.forEach((f) => changed.add(f))
 
         const linkChanged = await upsertPackageRepo(t, packageDbId.toString(), repoId, {
           source: 'declared',
+          signal: normalized.resolvedRepo.signal,
         })
         linkChanged.forEach((f) => changed.add(f))
       }

--- a/services/apps/packages_worker/src/rubygems/types.ts
+++ b/services/apps/packages_worker/src/rubygems/types.ts
@@ -1,4 +1,4 @@
-import { CanonicalRepo } from '../utils/canonicalizeRepoUrl'
+import { ResolvedManifestRepo } from '../utils/resolveManifestRepo'
 
 export interface BatchResult {
   processed: number
@@ -25,6 +25,7 @@ export interface RubyGemsGemResponse {
   info?: string | null
   homepage_uri?: string | null
   source_code_uri?: string | null
+  bug_tracker_uri?: string | null
   licenses?: string[] | null
   downloads?: number
 }
@@ -46,7 +47,7 @@ export interface NormalizedRubyGemsPackage {
   description: string | null
   homepage: string | null
   declaredRepositoryUrl: string | null
-  repo: CanonicalRepo | null
+  resolvedRepo: ResolvedManifestRepo | null
   licenses: string[] | null
   licensesRaw: string | null
   latestVersion: string | null

--- a/services/apps/packages_worker/src/scripts/rescorePackageRepos.ts
+++ b/services/apps/packages_worker/src/scripts/rescorePackageRepos.ts
@@ -54,7 +54,10 @@ async function main(): Promise<void> {
 
   const tiedPackages = await reportTies()
   if (tiedPackages > 0) {
-    log.warn({ tiedPackages }, 'Packages with tied confidence (repo_id DESC breaks ties deterministically)')
+    log.warn(
+      { tiedPackages },
+      'Packages with tied confidence (repo_id DESC breaks ties deterministically)',
+    )
   } else {
     log.info('No tied confidence values')
   }

--- a/services/apps/packages_worker/src/utils/__tests__/resolveManifestRepo.test.ts
+++ b/services/apps/packages_worker/src/utils/__tests__/resolveManifestRepo.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveManifestRepo } from '../resolveManifestRepo'
+
+describe('resolveManifestRepo', () => {
+  it('resolves the first candidate as primary', () => {
+    expect(
+      resolveManifestRepo([
+        { field: 'repository', url: 'git+https://github.com/babel/babel.git' },
+        { field: 'homepage', url: 'https://github.com/other/repo' },
+      ]),
+    ).toEqual({
+      repo: { url: 'https://github.com/babel/babel', host: 'github' },
+      signal: 'primary',
+      field: 'repository',
+    })
+  })
+
+  it('falls through to the next field when the primary one is missing', () => {
+    expect(
+      resolveManifestRepo([
+        { field: 'repository', url: null },
+        { field: 'homepage', url: 'https://github.com/foo/bar' },
+      ]),
+    ).toEqual({
+      repo: { url: 'https://github.com/foo/bar', host: 'github' },
+      signal: 'secondary',
+      field: 'homepage',
+    })
+  })
+
+  it('falls through when the primary field cannot be canonicalized', () => {
+    const resolved = resolveManifestRepo([
+      { field: 'repository', url: 'not a url' },
+      { field: 'bugs.url', url: 'https://gitlab.com/group/sub/project/-/issues' },
+    ])
+    expect(resolved?.repo.url).toBe('https://gitlab.com/group/sub/project')
+    expect(resolved?.signal).toBe('secondary')
+  })
+
+  it('rejects a secondary candidate that is not on a recognized VCS host', () => {
+    expect(
+      resolveManifestRepo([
+        { field: 'repository', url: null },
+        { field: 'homepage', url: 'https://example.com/docs/getting-started' },
+      ]),
+    ).toBeNull()
+  })
+
+  it('keeps a primary candidate on an unrecognized host', () => {
+    const resolved = resolveManifestRepo([
+      { field: 'repository', url: 'https://git.sr.ht/~sircmpwn/aerc' },
+    ])
+    expect(resolved?.repo.host).toBe('other')
+    expect(resolved?.signal).toBe('primary')
+  })
+
+  it('honours an explicit signal override', () => {
+    expect(
+      resolveManifestRepo([
+        { field: 'homepage', url: 'https://github.com/foo/bar', signal: 'secondary' },
+      ])?.signal,
+    ).toBe('secondary')
+  })
+
+  it('returns null when no candidate resolves', () => {
+    expect(resolveManifestRepo([{ field: 'repository', url: '   ' }])).toBeNull()
+  })
+})

--- a/services/apps/packages_worker/src/utils/__tests__/resolveManifestRepo.test.ts
+++ b/services/apps/packages_worker/src/utils/__tests__/resolveManifestRepo.test.ts
@@ -12,7 +12,6 @@ describe('resolveManifestRepo', () => {
     ).toEqual({
       repo: { url: 'https://github.com/babel/babel', host: 'github' },
       signal: 'primary',
-      field: 'repository',
     })
   })
 
@@ -25,7 +24,6 @@ describe('resolveManifestRepo', () => {
     ).toEqual({
       repo: { url: 'https://github.com/foo/bar', host: 'github' },
       signal: 'secondary',
-      field: 'homepage',
     })
   })
 

--- a/services/apps/packages_worker/src/utils/resolveManifestRepo.ts
+++ b/services/apps/packages_worker/src/utils/resolveManifestRepo.ts
@@ -1,0 +1,45 @@
+import type { PackageRepoSignal } from '@crowd/data-access-layer/src/packages/repoConfidence'
+
+import { CanonicalRepo, canonicalizeRepoUrl } from './canonicalizeRepoUrl'
+
+export interface ManifestRepoCandidate {
+  field: string
+  url: string | null | undefined
+  // Defaults to `primary` for the first candidate and `secondary` for the rest; set it
+  // when the primary field was already resolved elsewhere.
+  signal?: PackageRepoSignal
+}
+
+export interface ResolvedManifestRepo {
+  repo: CanonicalRepo
+  signal: PackageRepoSignal
+  field: string
+}
+
+/**
+ * Resolves a package's repository from the manifest fields that may carry it, in
+ * declaration order: the first candidate is the ecosystem's canonical repository
+ * field (`primary`), every later one a fallback (`secondary`).
+ *
+ * Fallback fields are free-form (homepage, docs, bug tracker), so they are only
+ * accepted on a recognized VCS host — an arbitrary `https://example.com/a/b`
+ * canonicalizes fine but is not a repo. The primary field keeps its historical
+ * behavior and accepts `other` hosts (self-hosted Gitea, cgit, SVN).
+ */
+export function resolveManifestRepo(
+  candidates: ManifestRepoCandidate[],
+): ResolvedManifestRepo | null {
+  for (const [index, candidate] of candidates.entries()) {
+    const raw = candidate.url?.trim()
+    if (!raw) continue
+
+    const repo = canonicalizeRepoUrl(raw)
+    if (!repo) continue
+
+    const signal: PackageRepoSignal = candidate.signal ?? (index === 0 ? 'primary' : 'secondary')
+    if (signal === 'secondary' && repo.host === 'other') continue
+
+    return { repo, signal, field: candidate.field }
+  }
+  return null
+}

--- a/services/apps/packages_worker/src/utils/resolveManifestRepo.ts
+++ b/services/apps/packages_worker/src/utils/resolveManifestRepo.ts
@@ -13,19 +13,8 @@ export interface ManifestRepoCandidate {
 export interface ResolvedManifestRepo {
   repo: CanonicalRepo
   signal: PackageRepoSignal
-  field: string
 }
 
-/**
- * Resolves a package's repository from the manifest fields that may carry it, in
- * declaration order: the first candidate is the ecosystem's canonical repository
- * field (`primary`), every later one a fallback (`secondary`).
- *
- * Fallback fields are free-form (homepage, docs, bug tracker), so they are only
- * accepted on a recognized VCS host — an arbitrary `https://example.com/a/b`
- * canonicalizes fine but is not a repo. The primary field keeps its historical
- * behavior and accepts `other` hosts (self-hosted Gitea, cgit, SVN).
- */
 export function resolveManifestRepo(
   candidates: ManifestRepoCandidate[],
 ): ResolvedManifestRepo | null {
@@ -39,7 +28,7 @@ export function resolveManifestRepo(
     const signal: PackageRepoSignal = candidate.signal ?? (index === 0 ? 'primary' : 'secondary')
     if (signal === 'secondary' && repo.host === 'other') continue
 
-    return { repo, signal, field: candidate.field }
+    return { repo, signal }
   }
   return null
 }

--- a/services/libs/data-access-layer/src/packages/packages.ts
+++ b/services/libs/data-access-layer/src/packages/packages.ts
@@ -320,6 +320,19 @@ export async function updatePackagistPackageStats(
   }
 }
 
+export async function setPackageRepositoryUrl(
+  qx: QueryExecutor,
+  packageId: string,
+  url: string,
+): Promise<string[]> {
+  const affected = await qx.result(
+    `UPDATE packages SET repository_url = $(url)
+      WHERE id = $(packageId)::bigint AND repository_url IS DISTINCT FROM $(url)`,
+    { url, packageId },
+  )
+  return affected > 0 ? ['packages.repository_url'] : []
+}
+
 export interface PackagistVersionAggregates {
   versionsCount: number
   latestVersion: string | null

--- a/services/libs/data-access-layer/src/packages/packages.ts
+++ b/services/libs/data-access-layer/src/packages/packages.ts
@@ -270,10 +270,16 @@ export interface PackagistStatsUpdateInput {
 export async function updatePackagistPackageStats(
   qx: QueryExecutor,
   input: PackagistStatsUpdateInput,
-): Promise<{ id: string; isCritical: boolean; changedFields: string[] } | null> {
-  const row: { id: string; is_critical: boolean; changed_fields: string[] } | undefined =
-    await qx.selectOneOrNone(
-      `WITH old AS (
+): Promise<{
+  id: string
+  isCritical: boolean
+  homepage: string | null
+  changedFields: string[]
+} | null> {
+  const row:
+    | { id: string; is_critical: boolean; homepage: string | null; changed_fields: string[] }
+    | undefined = await qx.selectOneOrNone(
+    `WITH old AS (
          SELECT description, declared_repository_url, repository_url, status,
                 total_downloads, dependent_count, ingestion_source
            FROM packages WHERE purl = $(purl) AND ecosystem = 'packagist'
@@ -288,10 +294,10 @@ export async function updatePackagistPackageStats(
            dependent_count           = COALESCE($(dependentCount), dependent_count),
            last_synced_at            = NOW()
          WHERE purl = $(purl) AND ecosystem = 'packagist'
-         RETURNING id, is_critical, description, declared_repository_url, repository_url, status,
-                   total_downloads, dependent_count, ingestion_source
+         RETURNING id, is_critical, homepage, description, declared_repository_url, repository_url,
+                   status, total_downloads, dependent_count, ingestion_source
        )
-       SELECT ins.id::text AS id, ins.is_critical,
+       SELECT ins.id::text AS id, ins.is_critical, ins.homepage,
               array_remove(ARRAY[
                 CASE WHEN o.description               IS DISTINCT FROM ins.description               THEN 'packages.description' END,
                 CASE WHEN o.declared_repository_url   IS DISTINCT FROM ins.declared_repository_url   THEN 'packages.declared_repository_url' END,
@@ -302,11 +308,16 @@ export async function updatePackagistPackageStats(
                 CASE WHEN o.ingestion_source          IS DISTINCT FROM ins.ingestion_source          THEN 'packages.ingestion_source' END
               ], NULL) AS changed_fields
          FROM ins LEFT JOIN old o ON true`,
-      input,
-    )
+    input,
+  )
 
   if (!row) return null
-  return { id: row.id, isCritical: row.is_critical, changedFields: row.changed_fields }
+  return {
+    id: row.id,
+    isCritical: row.is_critical,
+    homepage: row.homepage,
+    changedFields: row.changed_fields,
+  }
 }
 
 export interface PackagistVersionAggregates {


### PR DESCRIPTION
Part 2 of 3 for [CM-1392](https://linuxfoundation.atlassian.net/browse/CM-1392).

Stack: #4544 → **#4545 (this PR)** → #4546. Based on #4544 — review that one first; this diff is only meaningful on top of it.

## Problem

Every registry writer only created a link when the ecosystem's canonical repository field parsed — npm `repository`, cargo `repository`, rubygems `source_code_uri`, NuGet `<repository>`, POM `<scm><url>`. A large share of packages leave that field empty while publishing the same repo URL in `homepage`, `bugs.url`, `projectUrl`, `bug_tracker_uri`, or the POM `<url>`. Those packages got no repo link at all — invisible to criticality, blast radius, and Insights.

## What this does

One shared helper, `resolveManifestRepo(candidates)`, resolves a package's repo from an ordered candidate list. The first candidate is the ecosystem's canonical field and resolves as `primary`; every later one resolves as `secondary`. Writers persist the returned `signal` — no writer computes a confidence value, CM-1306's function already prices `secondary` at −0.10.

| Ecosystem | Chain |
| --- | --- |
| npm | `repository` → `homepage` → `bugs.url` |
| pypi | Source/Code project URL → `Homepage` → bug tracker |
| cargo | `repository` → `homepage` |
| rubygems | `source_code_uri` → `homepage_uri` → `bug_tracker_uri` |
| packagist | `support.source` → `homepage` |
| nuget | `<repository>` → `projectUrl` |
| maven | POM `<scm><url>` → POM `<url>` |

**Host gate.** Candidates go through the shared `canonicalizeRepoUrl`. A `secondary` candidate is rejected when canonicalization yields `host === 'other'` — recognized VCS hosts only, since a fallback field is free-form and `https://example.com/docs/intro` canonicalizes into a plausible `owner/repo` shape without being a repository. The `primary` candidate keeps its historical behaviour and still accepts `other`, so existing links to self-hosted Gitea, cgit, and SVN are unaffected. Packagist already applied this gate locally; it is now the shared rule.

**Cargo** differs in mechanics only: its pipeline is set-based SQL over a dump, so `normalizeRepos` stages both `declared_repository_url` and `homepage` into `repo_norm`, and a new `repo_choice` table applies the same first-wins-with-host-gate rule in SQL. `documentation` is not staged — it is almost always docs.rs, which the host gate rejects anyway.

**Maven** moves onto the shared canonicalizer as part of this PR; its own `parseRepoUrl` used substring host matching and would otherwise have accepted hosts the other ecosystems reject.

Per-run counters (`primary_field_hit`, `fallback_hit_by_field`, `no_signal`) log at loop end, following the existing per-run totals pattern.

## Before merge

Record per-ecosystem `package_repos` row counts so the coverage uplift is measurable against the counters.

## Decision record

[ADR-0021](docs/adr/0021-secondary-manifest-repository-signal.md) — includes why fallback candidates are host-gated while primary ones are not.


[CM-1392]: https://linuxfoundation.atlassian.net/browse/CM-1392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ