### PR TITLE
fix: repoScorecardChecks quarantine (IN-1264)

### DIFF
--- a/backend/src/osspckgs/migrations/U1788220800__fix_scorecard_checks_score_type.sql
+++ b/backend/src/osspckgs/migrations/U1788220800__fix_scorecard_checks_score_type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE repo_scorecard_checks
+  ALTER COLUMN score TYPE numeric(3, 1);

--- a/backend/src/osspckgs/migrations/V1788220800__fix_scorecard_checks_score_type.sql
+++ b/backend/src/osspckgs/migrations/V1788220800__fix_scorecard_checks_score_type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE repo_scorecard_checks
+  ALTER COLUMN score TYPE real;

--- a/services/apps/packages_worker/src/scorecard/workflows/ingestScorecard.ts
+++ b/services/apps/packages_worker/src/scorecard/workflows/ingestScorecard.ts
@@ -102,7 +102,7 @@ const SCORECARD_CHECKS_MERGE_SQL = `
 INSERT INTO repo_scorecard_checks (repo_id, check_name, score, reason)
 SELECT r.id,
        s.check_name,
-       NULLIF(s.check_score, -1)::numeric(3,1),
+       NULLIF(s.check_score, -1)::real,
        s.check_reason
 FROM (
   SELECT DISTINCT ON (repo_url, check_name) repo_url, check_name, check_score, check_reason

--- a/services/libs/tinybird/datasources/repoScorecardChecks.datasource
+++ b/services/libs/tinybird/datasources/repoScorecardChecks.datasource
@@ -5,7 +5,7 @@ DESCRIPTION >
     - `id` is the internal primary key.
     - `repoId` links to the parent repos row.
     - `checkName` is the Scorecard check identifier, e.g. 'Binary-Artifacts', 'Branch-Protection', 'Code-Review'.
-    - `score` is the numeric check score on a 0–10 scale (0 if the check failed or was not applicable).
+    - `score` is the numeric check score on a 0–10 scale. NULL means the check was not applicable.
     - `reason` is the human-readable explanation of the score (empty string if not provided).
     - `createdAt` and `updatedAt` are row-level audit timestamps for Tinybird watermark-based sync.
 
@@ -13,7 +13,7 @@ SCHEMA >
     `id` UInt64 `json:$.record.id`,
     `repoId` UInt64 `json:$.record.repo_id`,
     `checkName` String `json:$.record.check_name`,
-    `score` Float32 `json:$.record.score` DEFAULT 0,
+    `score` Nullable(Float32) `json:$.record.score`,
     `reason` String `json:$.record.reason` DEFAULT '',
     `createdAt` DateTime64(3) `json:$.record.created_at`,
     `updatedAt` DateTime64(3) `json:$.record.updated_at`


### PR DESCRIPTION
## Summary

- Fixes 46M quarantined rows in `repoScorecardChecks` datasource caused by Sequin serializing postgres `numeric(3,1)` as a JSON string, which Tinybird `Float32` rejects
- Migrates `repo_scorecard_checks.score` from `numeric(3,1)` to `real` so Sequin emits a JSON number
- Fixes null semantics: changes Tinybird column from `Float32 DEFAULT 0` to `Nullable(Float32)` so N/A checks land as NULL instead of conflating with score=0 (failed)
- Includes undo migration (`U1788220800`)

**Jira:** [IN-1264](https://linuxfoundation.atlassian.net/browse/IN-1264)

## Recovery (post-merge, manual)

1. Deploy Tinybird schema (`tb --cloud deploy`) — automatic ALTER, no rewrite
2. Truncate `repoScorecardChecks` in Tinybird
3. Trigger `ingestScorecard` workflow for full reingest from BigQuery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IN-1264]: https://linuxfoundation.atlassian.net/browse/IN-1264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ