### PR TITLE
chore: align pipeline schedules with agreed onboarding cadence (CM-1138)

### DIFF
--- a/services/apps/automatic_projects_discovery_worker/src/schedules/scheduleProjectsDiscovery.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/schedules/scheduleProjectsDiscovery.ts
@@ -15,14 +15,14 @@ export const scheduleProjectsDiscovery = async () => {
       },
       policies: {
         overlap: ScheduleOverlapPolicy.SKIP,
-        catchupWindow: '1 minute',
+        catchupWindow: '1 hour',
       },
       action: {
         type: 'startWorkflow',
         workflowType: discoverProjects,
         taskQueue: 'automatic-projects-discovery',
         args: [{ mode: 'incremental' as const }],
-        workflowExecutionTimeout: '2 hours',
+        workflowExecutionTimeout: '5 hours',
         retry: {
           initialInterval: '15 seconds',
           backoffCoefficient: 2,

--- a/services/apps/projects_evaluation_worker/src/schedules/scheduleProjectsEvaluation.ts
+++ b/services/apps/projects_evaluation_worker/src/schedules/scheduleProjectsEvaluation.ts
@@ -7,9 +7,9 @@ import { IEvaluateProjectsInput, evaluateProjects } from '../workflows'
 // - evaluateLimit: maximum number of projects in 'evaluate' state at any time.
 // - sourcePriority: ordered list of sources; earlier = higher priority; unlisted sources rank last.
 const EVALUATION_ARGS: IEvaluateProjectsInput = {
-  batchSize: 50,
+  batchSize: 20,
   priorityConfig: {
-    evaluateLimit: 50,
+    evaluateLimit: 20,
     sourcePriority: ['manual', 'insights-discussions'],
   },
 }
@@ -21,20 +21,18 @@ export const scheduleProjectsEvaluation = async () => {
     await svc.temporal.schedule.create({
       scheduleId: 'projectsEvaluation',
       spec: {
-        // Run every Monday at 02:00 UTC — gives time after the weekly discovery run.
-        cronExpressions: ['0 2 * * 1'],
+        cronExpressions: ['0 4 * * *'],
       },
       policies: {
         overlap: ScheduleOverlapPolicy.SKIP,
-        catchupWindow: '1 minute',
+        catchupWindow: '1 hour',
       },
       action: {
         type: 'startWorkflow',
         workflowType: evaluateProjects,
         taskQueue: 'projects-evaluation',
         args: [EVALUATION_ARGS],
-        // 50 projects × ~3min each = ~2.5h worst case; set ceiling with margin.
-        workflowExecutionTimeout: '6 hours',
+        workflowExecutionTimeout: '3 hours',
         retry: {
           initialInterval: '30 seconds',
           backoffCoefficient: 2,


### PR DESCRIPTION
## Summary
Aligns the discovery/evaluation/onboarding Temporal schedules with the cadence and limits agreed with Joana: evaluation moves from a weekly 50-project batch to a daily 20-project batch, matching the onboarding worker's existing daily 20-project limit, and closes a workflow timeout gap in discovery that made its own configured retries unreachable.

## Changes
- `projects_evaluation_worker`: cron `0 2 * * 1` (weekly) -> `0 4 * * *` (daily), scheduled between discovery (00:00) and onboarding (08:00) so the three phases never overlap.
- `projects_evaluation_worker`: `batchSize` / `evaluateLimit` 50 -> 20, matching the onboarding worker's batch size.
- `projects_evaluation_worker`: `workflowExecutionTimeout` 6h -> 3h, sized to the new 20-project worst case (~2h).
- `automatic_projects_discovery_worker`: `workflowExecutionTimeout` 2h -> 5h - the activity itself allows 90min x 3 attempts (4.5h worst case), so the previous 2h ceiling could kill a retry before it completed; 5h gives headroom above the real worst case.
- Both workers: `catchupWindow` 1 minute -> 1 hour - a 1-minute window meant a rolling deploy landing on the fire time could silently skip that day's run.

No code changes to the workflows/activities themselves - schedule configuration only.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
https://linuxfoundation.atlassian.net/browse/CM-1138

## Rollout note
These schedule changes only take effect in Temporal once the workers are redeployed. The existing `projectsEvaluation` and `automaticProjectsDiscovery` schedules in prod Temporal should be deleted after this deploy lands, so they get recreated with the new config on worker startup.
