### PR TITLE
fix: keep gh api auto-approval read-only in Claude Code settings

### DIFF
--- a/.claude/hooks/guard-gh-api.sh
+++ b/.claude/hooks/guard-gh-api.sh
@@ -37,17 +37,26 @@ block() {
   exit 2
 }
 
-if echo "$INPUT" | grep -qE '(^|[^[:alnum:]-])--method([= ]|\\")'; then
+# Long flags are matched as substrings so that quoting cannot hide them:
+# the shell strips quotes before gh sees the flag, but the raw hook input
+# still contains them, and "--method" is "--method" inside quotes or out.
+if echo "$INPUT" | grep -qE -- '--method'; then
   block "--method overrides the GET default."
 fi
-if echo "$INPUT" | grep -qE '(^|[[:space:]])-X'; then
-  block "-X overrides the GET default."
-fi
-if echo "$INPUT" | grep -qE '(^|[[:space:]])-(f|F)([[:alnum:]_=-]|[[:space:]]|\\")'; then
+if echo "$INPUT" | grep -qE -- '--(field|raw-field|input)'; then
   block "request parameters switch gh api from GET to POST."
 fi
-if echo "$INPUT" | grep -qE '(^|[^[:alnum:]-])--(field|raw-field|input)([= ]|\\")'; then
-  block "request parameters switch gh api from GET to POST."
+
+# Short flags cluster: gh accepts -iX DELETE and -XDELETE as readily as
+# -X DELETE (measured; --verbose shows the DELETE request line for each).
+# So the guard blocks any short-flag cluster containing X, f, or F. The
+# leading character class keeps a path segment like r-Xtra innocent while
+# still catching a quoted "-X", whose preceding character is a quote.
+if echo "$INPUT" | grep -qE -- '(^|[^[:alnum:]_-])-[[:alpha:]]*X'; then
+  block "-X (alone or in a flag cluster) overrides the GET default."
+fi
+if echo "$INPUT" | grep -qE -- '(^|[^[:alnum:]_-])-[[:alpha:]]*[fF]([^[:alpha:]]|$)'; then
+  block "request parameters (-f/-F) switch gh api from GET to POST."
 fi
 
 exit 0

--- a/.claude/hooks/guard-gh-api.sh
+++ b/.claude/hooks/guard-gh-api.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright The Linux Foundation and each contributor to CDP.
+# SPDX-License-Identifier: MIT
+#
+# Guard hook: keeps `gh api` read-only.
+# Used by Claude Code PreToolUse hook on Bash operations.
+#
+# The permissions allow-list auto-approves `gh api repos*` so the review-pr
+# skill can read PR comments, reviews, and commits. A prefix rule cannot see
+# the HTTP method, and `gh api` switches from GET to POST the moment any
+# parameter is added (`-f`/`-F`), or to anything at all via `-X/--method`.
+# This hook closes that gap: reads pass through, writes are blocked.
+#
+# Exit code 0 = allow. Exit code 2 = block (stderr is shown to Claude).
+
+set -euo pipefail
+
+# Read tool input from stdin (JSON with a command field). The flags are
+# matched on the raw JSON rather than an extracted command string, so a
+# quote inside the command cannot hide a flag from the guard. That can
+# over-match a flag mentioned inside e.g. a --jq expression; the failure
+# mode is a block message asking to rephrase, never a silent write.
+INPUT=$(cat)
+
+# Only guard gh api invocations.
+if ! echo "$INPUT" | grep -q 'gh api'; then
+  exit 0
+fi
+
+block() {
+  echo "" >&2
+  echo "✗ BLOCKED: gh api is allowed for reads only." >&2
+  echo "Reason: $1" >&2
+  echo "The allow-list approves gh api so /review-pr can fetch PR comments, reviews, and commits." >&2
+  echo "A request that changes state needs to be run by a human, outside this rule." >&2
+  echo "" >&2
+  exit 2
+}
+
+if echo "$INPUT" | grep -qE '(^|[^[:alnum:]-])--method([= ]|\\")'; then
+  block "--method overrides the GET default."
+fi
+if echo "$INPUT" | grep -qE '(^|[[:space:]])-X'; then
+  block "-X overrides the GET default."
+fi
+if echo "$INPUT" | grep -qE '(^|[[:space:]])-(f|F)([[:alnum:]_=-]|[[:space:]]|\\")'; then
+  block "request parameters switch gh api from GET to POST."
+fi
+if echo "$INPUT" | grep -qE '(^|[^[:alnum:]-])--(field|raw-field|input)([= ]|\\")'; then
+  block "request parameters switch gh api from GET to POST."
+fi
+
+exit 0

--- a/.claude/hooks/guard-gh-api.sh
+++ b/.claude/hooks/guard-gh-api.sh
@@ -47,16 +47,25 @@ if echo "$INPUT" | grep -qE -- '--(field|raw-field|input)'; then
   block "request parameters switch gh api from GET to POST."
 fi
 
-# Short flags cluster: gh accepts -iX DELETE and -XDELETE as readily as
-# -X DELETE (measured; --verbose shows the DELETE request line for each).
-# So the guard blocks any short-flag cluster containing X, f, or F. The
-# leading character class keeps a path segment like r-Xtra innocent while
-# still catching a quoted "-X", whose preceding character is a quote.
+# Short flags: gh parses with spf13/pflag, whose documentation admits
+# exactly three value spellings ("-n 1234", "-n=1234", "-n1234") plus
+# boolean clustering ("-abcs1234" is -a -b -c -s 1234). Every method-
+# changing spelling is therefore one token: a dash, optional letters,
+# then X, f, or F, with the value either attached or not. All measured:
+# -XDELETE, -iX DELETE, -fkey=value, -f=key=value, and -ifkey=value each
+# show the non-GET request line under --verbose. So the guard blocks any
+# short-flag cluster containing X, f, or F, with no constraint on what
+# follows the letter: an attached value follows it immediately, which is
+# why requiring a boundary there was itself a bypass. The leading class
+# keeps a path segment like r-Xtra innocent while still catching a quoted
+# "-X", whose preceding character is a quote. Prose like "-friendly" also
+# blocks, and that is not over-matching: gh reads it as -f riendly and
+# says so ("invalid key: riendly").
 if echo "$INPUT" | grep -qE -- '(^|[^[:alnum:]_-])-[[:alpha:]]*X'; then
   block "-X (alone or in a flag cluster) overrides the GET default."
 fi
-if echo "$INPUT" | grep -qE -- '(^|[^[:alnum:]_-])-[[:alpha:]]*[fF]([^[:alpha:]]|$)'; then
-  block "request parameters (-f/-F) switch gh api from GET to POST."
+if echo "$INPUT" | grep -qE -- '(^|[^[:alnum:]_-])-[[:alpha:]]*[fF]'; then
+  block "request parameters (-f/-F, attached or separate) switch gh api from GET to POST."
 fi
 
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,15 @@
             "command": ".claude/hooks/guard-protected-files.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/guard-gh-api.sh"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary

`Bash(gh api repos*)` in `.claude/settings.json` was added so the `review-pr` skill can fetch PR comments, reviews, and commits, and it sits in a block of otherwise read-only `gh` rules. A prefix rule cannot see the HTTP method, so the same rule also auto-approves writes. This PR adds a PreToolUse guard, in the same shape as the existing `guard-protected-files.sh`, that lets `gh api` reads through untouched and blocks anything that changes the request method.

Everything below was measured on Claude Code 2.1.238 before opening this PR (each rule set in a scratch `settings.json` passed via `--settings`, raw `stream-json` transcripts, probes against a repo name that does not exist so the API returns 404 and nothing changes):

| Command | Rule as on main | Rule + this guard |
| --- | --- | --- |
| `gh api repos/linuxfoundation/crowd.dev/pulls/4548/comments --paginate` | auto-approved (returns the PR's 21 inline comments) | auto-approved, unchanged |
| `gh api repos/<owner>/<repo> -X DELETE` | auto-approved | blocked by the guard |
| `gh api repos/<owner>/<repo> -f description=x` | auto-approved | blocked by the guard |
| `gh api repos/<owner>/<repo>/git/refs/heads/main -X DELETE` | auto-approved | blocked by the guard |

Two details worth knowing:

- The POST case needs no `-X`: gh's own help says "adding request parameters will automatically switch the request method to POST", so any `-f`/`-F` ride-along turns an approved read into a write.
- With a default `gh auth login` token (`repo` scope, no `delete_repo`), repository deletion itself would fail at the API. What the `repo` scope does cover through this rule: deleting branches via `git/refs`, editing repository settings via PATCH, and deleting comments and releases.

The deny list already blocks `git reset --hard*` and `rm -rf*`, so this brings remote state in line with the protection local state already has.

## Changes

- `.claude/hooks/guard-gh-api.sh`: blocks `-X`/`--method` and the parameter flags that imply POST (`-f`, `-F`, `--field`, `--raw-field`, `--input`) on `gh api` commands; exits 2 with an explanation. The flag scan runs on the raw hook input rather than an extracted command string, so a quote inside the command cannot hide a flag from the guard (unit-tested against a `--jq '"' -X DELETE` smuggle).
- `.claude/settings.json`: wires the guard into `PreToolUse` with a `Bash` matcher, next to the existing `Edit|Write|MultiEdit` guard.

The `review-pr` skill's three documented `gh api` calls (comments, reviews, commits) were re-run under the guarded config and still auto-approve.

## Type of change

- [x] Bug fix

## JIRA ticket

n/a (external contribution; happy to reference one if a maintainer files it)

## Notes for the reviewer

One deliberate trade-off: the guard blocks `gh api` writes outright rather than downgrading them to an approval prompt, matching the hard-deny style of your deny list. If you would rather keep human-approvable writes in interactive sessions, the exit-2 block can be swapped for a hook JSON `permissionDecision: "ask"`; I kept the measured, simpler contract. An alternative to all of this is deleting the `Bash(gh api repos*)` line and letting the three skill calls prompt each review session; the hook keeps the skill friction-free, which seemed closer to the intent of #4122.

Found while testing a static analysis tool for agent configuration files; every claim above was then verified by hand against Claude Code before this PR was opened.
