### PR TITLE
feat: sink healthLabel to health_score_sink for dbt (IN-1262)

### DIFF
--- a/services/libs/tinybird/pipes/health_score_sink.pipe
+++ b/services/libs/tinybird/pipes/health_score_sink.pipe
@@ -11,6 +11,7 @@ SQL >
         if(isNaN(hs.popularityPercentage), null, hs.popularityPercentage) as popularityPercentage,
         if(isNaN(hs.developmentPercentage), null, hs.developmentPercentage) as developmentPercentage,
         p.healthScoreV2 as overall_score_v2,
+        p.healthLabel as health_label_v2,
         p.coveredCategoryCount as covered_category_count_v2,
         p.healthMaxScore as health_max_score_v2,
         toStartOfDay(now()) as date


### PR DESCRIPTION
## Summary
- `health_score_sink.pipe` feeds the warehouse (dbt/Snowflake), which independently recomputes `health_score_category_v2` from the raw `overall_score_v2` — a value that's uncapped/unnormalized for partial-coverage (2-of-3 category) projects.
- `project_insights_copy.pipe` already computes the correct, normalized category as `healthLabel`, but it was never sunk here — dbt had no way to consume it.
- Adds `p.healthLabel as health_label_v2` to the export so dbt can pass it through directly instead of recomputing. Companion `lf-dbt` PR: linuxfoundation/lf-dbt#2863

## Deploy order
Merge and deploy this first — `lf-dbt`'s change reads `health_label_v2` from this sink's Kafka export.