### PR TITLE
fix: append health_label_v2 at end of health_score_sink select (IN-1262)

### DIFF
--- a/services/libs/tinybird/pipes/health_score_sink.pipe
+++ b/services/libs/tinybird/pipes/health_score_sink.pipe
@@ -11,9 +11,9 @@ SQL >
         if(isNaN(hs.popularityPercentage), null, hs.popularityPercentage) as popularityPercentage,
         if(isNaN(hs.developmentPercentage), null, hs.developmentPercentage) as developmentPercentage,
         p.healthScoreV2 as overall_score_v2,
-        p.healthLabel as health_label_v2,
         p.coveredCategoryCount as covered_category_count_v2,
         p.healthMaxScore as health_max_score_v2,
+        p.healthLabel as health_label_v2,
         toStartOfDay(now()) as date
     FROM health_score_copy_ds AS hs
     LEFT JOIN project_insights_copy_ds AS p ON hs.id = p.id AND p.type = 'project'


### PR DESCRIPTION
## Summary
Follow-up to #4559. `health_score_sink` is a `SINK` pipe exporting CSV rows to Kafka for dbt/Snowflake ingestion — CSV is positional. The prior commit inserted `health_label_v2` mid-list, shifting the position of `covered_category_count_v2`, `health_max_score_v2`, and `date` for the next scheduled export (00:30 UTC daily).

This moves `health_label_v2` to the end of the SELECT so every pre-existing column keeps its original position.

## Test plan
- [ ] Confirm dbt's `bronze_kafka_crowd_dev_health_score_sink` still ingests all fields correctly after the next scheduled export