### PR TITLE
fix: treat pkg.go.dev total:-1 as unknown versionsCount (IN-1270)

### DIFF
--- a/services/apps/packages_worker/src/go/pkgGoDevClient.ts
+++ b/services/apps/packages_worker/src/go/pkgGoDevClient.ts
@@ -87,7 +87,9 @@ export async function fetchStatus(
     onHeartbeat?.()
     if (isFetchError(result)) return result
 
-    if (versionsCount === null && typeof result.total === 'number') versionsCount = result.total
+    // pkg.go.dev returns total: -1 when the count is unresolvable (IN-1270); treat as unknown.
+    if (versionsCount === null && typeof result.total === 'number' && result.total >= 0)
+      versionsCount = result.total
     const items = result.items ?? []
     const latestVersion = items.find((i) => i.latestVersion)?.latestVersion
     const match = latestVersion ? items.find((i) => i.version === latestVersion) : undefined


### PR DESCRIPTION
## Summary
- pkg.go.dev's `/v1beta/versions/<module>` API returns `total: -1` for some Go modules whose version count can't be resolved.
- `fetchStatus()` in `pkgGoDevClient.ts` was passing that value straight through to `versionsCount`, which Postgres accepts (nullable int) but Tinybird's `ossPackages` datasource rejects (`Nullable(UInt32)` is unsigned), quarantining the row.
- Now `total < 0` is treated as unknown and `versionsCount` stays `null`, matching the existing `COALESCE` fallback semantics in `activities.ts` ("don't change existing value" for unresolvable counts).

JIRA: IN-1270

## Test plan
- [x] `pnpm lint` clean on `packages_worker`
- [ ] Confirm next Go enrichment run for a previously-quarantined `purl` (e.g. `pkg:golang/github.com/rvolosatovs/redis`) no longer quarantines
- Follow-up (tracked in IN-1270, not part of this PR): backfill/re-ingest the 276K existing quarantined `ossPackages` rows