### PR TITLE
feat: secondary manifest repository signal (CM-1393)

### DIFF
--- a/backend/src/osspckgs/migrations/V1788307300__package_repo_signal.sql
+++ b/backend/src/osspckgs/migrations/V1788307300__package_repo_signal.sql
@@ -148,7 +148,8 @@ BEGIN
             ),
             updated AS (
                 UPDATE package_repos pr
-                   SET confidence = s.confidence, verified_at = NOW()
+                   SET confidence = s.confidence,
+                       verified_at = GREATEST(clock_timestamp(), cur.verified_at + interval '1 millisecond')
                   FROM batch b
                   JOIN package_repos cur ON cur.id = b.id
                   JOIN packages p ON p.id = cur.package_id

--- a/backend/src/osspckgs/migrations/V1788307300__package_repo_signal.sql
+++ b/backend/src/osspckgs/migrations/V1788307300__package_repo_signal.sql
@@ -1,0 +1,178 @@
+-- Secondary manifest repository signal (CM-1393).
+--
+-- Extends the confidence scoring introduced in V1788307200 with the manifest field
+-- that produced a declared link. A repo URL read from a fallback field (homepage,
+-- bug_tracker) is weaker evidence than one read from the dedicated repository field,
+-- so it lands one tier lower.
+--
+-- The column defaults to 'primary', so existing rows keep their current score until
+-- the next enrichment pass writes a real signal or a rescore sweep runs.
+
+ALTER TABLE package_repos
+    ADD COLUMN IF NOT EXISTS signal text NOT NULL DEFAULT 'primary'
+        CHECK (signal IN ('primary', 'secondary'));
+
+-- Adding a parameter changes the signature, so the V1788307200 function is dropped
+-- rather than replaced — CREATE OR REPLACE would leave both overloads callable.
+DROP FUNCTION IF EXISTS package_repo_confidence(
+    text, text, text, bool, bool, bool, text, bool, bigint
+);
+
+CREATE OR REPLACE FUNCTION package_repo_confidence(
+    p_source           text,
+    p_ecosystem        text,
+    p_signal           text,
+    p_provenance       text,
+    p_archived         bool,
+    p_is_fork          bool,
+    p_disabled         bool,
+    p_host             text,
+    p_competing_github bool,
+    p_repo_id          bigint
+)
+RETURNS numeric(12, 9)
+LANGUAGE plpgsql IMMUTABLE AS $$
+DECLARE
+    base            numeric;
+    source_priority int;
+    offset_units    bigint;
+BEGIN
+    base := CASE p_source
+        WHEN 'manual'    THEN 0.99
+        WHEN 'heuristic' THEN 0.30
+        WHEN 'deps_dev'  THEN CASE p_provenance
+            WHEN 'SLSA_ATTESTATION'             THEN 0.99
+            WHEN 'RUBYGEMS_PUBLISH_ATTESTATION' THEN 0.95
+            WHEN 'PYPI_PUBLISH_ATTESTATION'     THEN 0.95
+            WHEN 'GO_ORIGIN'                    THEN 0.90
+            ELSE 0.50
+        END
+        -- maven splits off npm/cargo/the rest: POM <scm> blocks are notoriously
+        -- stale (legacy SVN URLs, org renames, dead mirrors).
+        WHEN 'declared' THEN CASE WHEN p_ecosystem = 'maven' THEN 0.80 ELSE 0.85 END
+        ELSE 0.30
+    END;
+
+    -- Signal adjusts the declared tier only. A deps.dev publish attestation already
+    -- proves the publisher–repo relationship, and manual links are operator-pinned.
+    IF p_source = 'declared' AND p_signal = 'secondary' THEN
+        base := base - 0.10;
+    END IF;
+
+    source_priority := CASE p_source
+        WHEN 'manual'    THEN 3
+        WHEN 'deps_dev'  THEN 2
+        WHEN 'declared'  THEN 1
+        ELSE 0
+    END;
+
+    IF p_disabled IS TRUE THEN
+        -- Scale proportionally so pre-disabled claim ordering is preserved across sources.
+        -- The offset uses a tighter modulo so max contribution (3*1000+999)*1e-9 ≈ 4e-6
+        -- stays below the 0.00016 minimum scaled tier gap and cannot invert source ordering.
+        base := 0.05 + LEAST(base, 0.99) * 0.004;
+        offset_units := source_priority::bigint * 1000 + COALESCE(p_repo_id, 0) % 1000;
+    ELSE
+        IF p_archived IS TRUE THEN
+            base := base - 0.20;
+        END IF;
+
+        IF p_is_fork IS TRUE THEN
+            base := base - 0.10;
+        END IF;
+
+        IF p_competing_github IS TRUE AND p_host IS NOT NULL AND p_host <> 'github' THEN
+            base := base - 0.05;
+        END IF;
+
+        base := GREATEST(base, 0.05);
+
+        -- Tie-breaker: reduces same-source collisions to the rare case where two repo IDs for
+        -- the same package are congruent mod 1,000,000. BEST_REPO_LINK_JOIN uses a secondary
+        -- ORDER BY repo_id DESC as the canonical deterministic pick when confidence ties.
+        offset_units := source_priority::bigint * 1000000 + COALESCE(p_repo_id, 0) % 1000000;
+    END IF;
+
+    RETURN LEAST(base + offset_units * 0.000000001, 0.999999999);
+END;
+$$;
+
+-- Replaced only to pass cur.signal through to the widened scoring function; the
+-- chunking, locking and keyset paging are unchanged from V1788307200.
+CREATE OR REPLACE PROCEDURE rescore_package_repo_confidence(
+    p_repo_ids   bigint[] DEFAULT NULL,
+    chunk_size   int      DEFAULT 25000,
+    INOUT applied_rows int DEFAULT 0
+)
+LANGUAGE plpgsql AS $$
+DECLARE
+    batch_rows   int;
+    updated_rows int;
+    cursor_id    bigint := 0;
+BEGIN
+    IF chunk_size IS NULL OR chunk_size <= 0 THEN
+        RAISE EXCEPTION 'rescore_package_repo_confidence: chunk_size must be positive, got %', chunk_size;
+    END IF;
+
+    -- Session-level: survives the internal COMMITs below.
+    IF NOT pg_try_advisory_lock(hashtextextended('rescore_package_repo_confidence', 0)) THEN
+        RAISE EXCEPTION 'rescore_package_repo_confidence: another execution is already in progress';
+    END IF;
+
+    applied_rows := 0;
+
+    LOOP
+            WITH batch AS (
+                SELECT pr.id
+                  FROM package_repos pr
+                 WHERE pr.id > cursor_id
+                   AND (p_repo_ids IS NULL OR pr.repo_id = ANY(p_repo_ids))
+                   -- deps_dev rows with NULL provenance were ingested before this column existed;
+                   -- skip them so the backfill does not downgrade SLSA/attestation links to 0.50.
+                   -- They will be rescored correctly once the next ingest populates provenance.
+                   AND NOT (pr.source = 'deps_dev' AND pr.provenance IS NULL)
+                 ORDER BY pr.id
+                 LIMIT chunk_size
+                   FOR UPDATE
+            ),
+            updated AS (
+                UPDATE package_repos pr
+                   SET confidence = s.confidence, verified_at = NOW()
+                  FROM batch b
+                  JOIN package_repos cur ON cur.id = b.id
+                  JOIN packages p ON p.id = cur.package_id
+                  JOIN repos r ON r.id = cur.repo_id,
+                       LATERAL (
+                         SELECT package_repo_confidence(
+                           cur.source, p.ecosystem, cur.signal, cur.provenance,
+                           r.archived, r.is_fork, r.disabled, r.host,
+                           EXISTS (
+                             SELECT 1
+                               FROM package_repos c
+                               JOIN repos cr ON cr.id = c.repo_id
+                              WHERE c.package_id = cur.package_id
+                                AND c.repo_id <> cur.repo_id
+                                AND cr.host = 'github'
+                           ),
+                           cur.repo_id
+                         ) AS confidence
+                       ) s
+                 WHERE pr.id = b.id
+                   AND s.confidence IS DISTINCT FROM cur.confidence
+                RETURNING pr.id
+            )
+            SELECT COUNT(*), COALESCE(MAX(b.id), cursor_id),
+                   (SELECT COUNT(*) FROM updated)
+              INTO batch_rows, cursor_id, updated_rows
+              FROM batch b;
+
+            applied_rows := applied_rows + updated_rows;
+
+            COMMIT;
+
+            EXIT WHEN batch_rows < chunk_size;
+        END LOOP;
+
+    PERFORM pg_advisory_unlock(hashtextextended('rescore_package_repo_confidence', 0));
+END;
+$$;

--- a/backend/src/osspckgs/migrations/V1788307300__package_repo_signal.sql
+++ b/backend/src/osspckgs/migrations/V1788307300__package_repo_signal.sql
@@ -1,22 +1,15 @@
--- Secondary manifest repository signal (CM-1393).
---
--- Extends the confidence scoring introduced in V1788307200 with the manifest field
--- that produced a declared link. A repo URL read from a fallback field (homepage,
--- bug_tracker) is weaker evidence than one read from the dedicated repository field,
--- so it lands one tier lower.
---
--- The column defaults to 'primary', so existing rows keep their current score until
--- the next enrichment pass writes a real signal or a rescore sweep runs.
+-- Secondary manifest repository signal (CM-1393): a declared link sourced from a
+-- fallback field (homepage/bug_tracker) scores one tier below a dedicated repository field.
 
 ALTER TABLE package_repos
-    ADD COLUMN IF NOT EXISTS signal text NOT NULL DEFAULT 'primary'
-        CHECK (signal IN ('primary', 'secondary'));
+    ADD COLUMN IF NOT EXISTS signal text NOT NULL DEFAULT 'primary';
 
--- Adding a parameter changes the signature, so the V1788307200 function is dropped
--- rather than replaced — CREATE OR REPLACE would leave both overloads callable.
-DROP FUNCTION IF EXISTS package_repo_confidence(
-    text, text, text, bool, bool, bool, text, bool, bigint
-);
+-- NOT VALID + separate VALIDATE so the existing-row scan takes the less disruptive
+-- validation lock instead of blocking registry writers under ADD COLUMN's stronger lock.
+ALTER TABLE package_repos
+    ADD CONSTRAINT package_repos_signal_check CHECK (signal IN ('primary', 'secondary')) NOT VALID;
+ALTER TABLE package_repos
+    VALIDATE CONSTRAINT package_repos_signal_check;
 
 CREATE OR REPLACE FUNCTION package_repo_confidence(
     p_source           text,
@@ -67,9 +60,8 @@ BEGIN
     END;
 
     IF p_disabled IS TRUE THEN
-        -- Scale proportionally so pre-disabled claim ordering is preserved across sources.
-        -- The offset uses a tighter modulo so max contribution (3*1000+999)*1e-9 ≈ 4e-6
-        -- stays below the 0.00016 minimum scaled tier gap and cannot invert source ordering.
+        -- Scale proportionally to preserve source ordering; the tighter modulo keeps the max
+        -- offset contribution (≈4e-6) below the 0.00016 minimum tier gap so it can't invert it.
         base := 0.05 + LEAST(base, 0.99) * 0.004;
         offset_units := source_priority::bigint * 1000 + COALESCE(p_repo_id, 0) % 1000;
     ELSE
@@ -87,14 +79,34 @@ BEGIN
 
         base := GREATEST(base, 0.05);
 
-        -- Tie-breaker: reduces same-source collisions to the rare case where two repo IDs for
-        -- the same package are congruent mod 1,000,000. BEST_REPO_LINK_JOIN uses a secondary
-        -- ORDER BY repo_id DESC as the canonical deterministic pick when confidence ties.
+        -- Tie-breaker: collisions only when two repo IDs for the same package are congruent
+        -- mod 1,000,000; BEST_REPO_LINK_JOIN's ORDER BY repo_id DESC then picks deterministically.
         offset_units := source_priority::bigint * 1000000 + COALESCE(p_repo_id, 0) % 1000000;
     END IF;
 
     RETURN LEAST(base + offset_units * 0.000000001, 0.999999999);
 END;
+$$;
+
+-- Compat overload for callers still on the pre-signal signature during a rolling deploy;
+-- delegates to the widened function as 'primary'. Drop in a later cleanup migration.
+CREATE OR REPLACE FUNCTION package_repo_confidence(
+    p_source           text,
+    p_ecosystem        text,
+    p_provenance       text,
+    p_archived         bool,
+    p_is_fork          bool,
+    p_disabled         bool,
+    p_host             text,
+    p_competing_github bool,
+    p_repo_id          bigint
+)
+RETURNS numeric(12, 9)
+LANGUAGE sql IMMUTABLE AS $$
+    SELECT package_repo_confidence(
+        p_source, p_ecosystem, 'primary', p_provenance, p_archived,
+        p_is_fork, p_disabled, p_host, p_competing_github, p_repo_id
+    )
 $$;
 
 -- Replaced only to pass cur.signal through to the widened scoring function; the
@@ -127,9 +139,8 @@ BEGIN
                   FROM package_repos pr
                  WHERE pr.id > cursor_id
                    AND (p_repo_ids IS NULL OR pr.repo_id = ANY(p_repo_ids))
-                   -- deps_dev rows with NULL provenance were ingested before this column existed;
-                   -- skip them so the backfill does not downgrade SLSA/attestation links to 0.50.
-                   -- They will be rescored correctly once the next ingest populates provenance.
+                   -- deps_dev rows with NULL provenance predate this column; skip them so the
+                   -- backfill doesn't downgrade SLSA/attestation links — a later ingest fixes it.
                    AND NOT (pr.source = 'deps_dev' AND pr.provenance IS NULL)
                  ORDER BY pr.id
                  LIMIT chunk_size

--- a/docs/adr/0021-secondary-manifest-repository-signal.md
+++ b/docs/adr/0021-secondary-manifest-repository-signal.md
@@ -28,7 +28,7 @@ One shared helper, `resolveManifestRepo(candidates)`
 (`packages_worker/src/utils/resolveManifestRepo.ts`), resolves a package's repo
 from an ordered candidate list. The first candidate is the ecosystem's canonical
 field and resolves as `primary`; every later candidate resolves as `secondary`.
-The result carries `{ repo, signal, field }`, and each writer persists the
+The result carries `{ repo, signal }`, and each writer persists the
 returned `signal` on the link. No writer computes a confidence value.
 
 ### Chains
@@ -58,43 +58,6 @@ SQL over a dump, so `normalizeRepos` stages both `declared_repository_url` and
 first-wins-with-host-gate rule in SQL. `documentation` is not staged — it is
 almost always docs.rs, which the host gate rejects anyway.
 
-## Alternatives Considered
-
-### Alternative 1: Widen each writer's existing extractor in place
-
-- **Pros**: no new module; smallest diff per ecosystem.
-- **Cons**: seven copies of the fallback order and the host gate, which is how
-  the current per-ecosystem divergence arose in the first place; the `signal`
-  value would be derived independently in each writer.
-- **Why not**: the whole point is one rule; nine implementations of "which
-  field won" is the defect, not the fix.
-
-### Alternative 2: Accept fallback URLs on any host, like the primary field does
-
-- **Pros**: maximum coverage; no URL is discarded.
-- **Cons**: a documentation site or a marketing page with two path segments
-  becomes a repo link, creating a `repos` row and an incorrect
-  `packages_published` attribution — the exact failure this epic exists to fix.
-- **Why not**: coverage gained by inventing repos is negative value; the
-  primary field at least carries the publisher's explicit claim.
-
-### Alternative 3: Score fallback links lower directly in the writers instead of adding `signal`
-
-- **Pros**: no schema column; visible in one place.
-- **Cons**: reintroduces per-writer confidence literals, and the penalty could
-  not be retuned or audited afterwards — nothing records *why* a row scored
-  lower.
-- **Why not**: ADR-0020 makes the stored score derivable from stored evidence;
-  `signal` is that evidence.
-
-### Alternative 4: Backfill a separate pass that mines fallback fields for packages with no link
-
-- **Pros**: zero risk to the existing write paths; can be re-run at will.
-- **Cons**: a second code path that has to re-fetch or re-read every manifest,
-  and it goes stale the moment a package is re-ingested.
-- **Why not**: the data is already in hand at write time; the write path is
-  the cheapest place to fix coverage.
-
 ## Consequences
 
 ### Positive
@@ -110,8 +73,9 @@ almost always docs.rs, which the host gate rejects anyway.
 
 - Secondary links are, by construction, less certain than declared ones; some
   will be wrong even with the host gate.
-- Maven and cargo needed local restructuring (maven onto the shared
-  canonicalizer, cargo's `repo_choice` in SQL) to reach the same behaviour.
+- Maven and cargo needed local restructuring (maven's POM-specific
+  `normalizeScmUrl` feeds the same `package_repos` write path; cargo's
+  `repo_choice` applies the host-gate rule in SQL) to reach the same behaviour.
 - Row counts in `package_repos` grow, and the dedup/keep-highest path now sees
   more competing links per package.
 

--- a/docs/adr/0021-secondary-manifest-repository-signal.md
+++ b/docs/adr/0021-secondary-manifest-repository-signal.md
@@ -1,0 +1,131 @@
+# ADR-0021: Secondary manifest repository signal
+
+**Date**: 2026-09-01
+**Status**: accepted
+**Deciders**: Joana Maia
+
+## Context
+
+Every registry writer only created a `package_repos` row when the ecosystem's
+canonical repository field parsed — npm `repository`, cargo `repository`,
+rubygems `source_code_uri`, NuGet `<repository>`, POM `<scm><url>`. A large
+share of packages leave that field empty while publishing the same repo URL in
+`homepage`, `bugs.url`, `projectUrl`, `bug_tracker_uri`, or the POM `<url>`, and
+those packages ended up with no repo link at all — invisible to criticality,
+blast radius, and Insights.
+
+Simply widening each writer to accept any of those fields would trade
+under-coverage for wrong links: fallback fields are free-form, so
+`https://example.com/docs/getting-started` canonicalizes into a plausible
+`owner/repo` shape without being a repository. Fallback links also should not
+rank equally with a declared one.
+[ADR-0020](./0020-package-repo-confidence-scoring.md) already reserved the
+`signal` column and its −0.10 penalty for exactly this.
+
+## Decision
+
+One shared helper, `resolveManifestRepo(candidates)`
+(`packages_worker/src/utils/resolveManifestRepo.ts`), resolves a package's repo
+from an ordered candidate list. The first candidate is the ecosystem's canonical
+field and resolves as `primary`; every later candidate resolves as `secondary`.
+The result carries `{ repo, signal, field }`, and each writer persists the
+returned `signal` on the link. No writer computes a confidence value.
+
+### Chains
+
+| Ecosystem | Chain |
+| --- | --- |
+| npm | `repository` → `homepage` → `bugs.url` |
+| pypi | Source/Code project URL → `Homepage` → bug tracker URL |
+| cargo | `repository` → `homepage` |
+| rubygems | `source_code_uri` → `homepage_uri` → `bug_tracker_uri` |
+| packagist | `support.source` → `homepage` |
+| nuget | `<repository>` → `projectUrl` |
+| maven | POM `<scm><url>` → POM `<url>` |
+
+### Host gate
+
+Candidates go through the shared `canonicalizeRepoUrl`. A `secondary` candidate
+is rejected when canonicalization yields `host === 'other'` — recognized VCS
+hosts only. The `primary` candidate keeps its historical behaviour and still
+accepts `other`, so existing links to self-hosted Gitea, cgit, and SVN are
+unaffected. Packagist already applied this gate locally; it is now the shared
+rule.
+
+Cargo is the exception on mechanics, not on policy: its pipeline is set-based
+SQL over a dump, so `normalizeRepos` stages both `declared_repository_url` and
+`homepage` into `repo_norm`, and a new `repo_choice` table applies the same
+first-wins-with-host-gate rule in SQL. `documentation` is not staged — it is
+almost always docs.rs, which the host gate rejects anyway.
+
+## Alternatives Considered
+
+### Alternative 1: Widen each writer's existing extractor in place
+
+- **Pros**: no new module; smallest diff per ecosystem.
+- **Cons**: seven copies of the fallback order and the host gate, which is how
+  the current per-ecosystem divergence arose in the first place; the `signal`
+  value would be derived independently in each writer.
+- **Why not**: the whole point is one rule; nine implementations of "which
+  field won" is the defect, not the fix.
+
+### Alternative 2: Accept fallback URLs on any host, like the primary field does
+
+- **Pros**: maximum coverage; no URL is discarded.
+- **Cons**: a documentation site or a marketing page with two path segments
+  becomes a repo link, creating a `repos` row and an incorrect
+  `packages_published` attribution — the exact failure this epic exists to fix.
+- **Why not**: coverage gained by inventing repos is negative value; the
+  primary field at least carries the publisher's explicit claim.
+
+### Alternative 3: Score fallback links lower directly in the writers instead of adding `signal`
+
+- **Pros**: no schema column; visible in one place.
+- **Cons**: reintroduces per-writer confidence literals, and the penalty could
+  not be retuned or audited afterwards — nothing records *why* a row scored
+  lower.
+- **Why not**: ADR-0020 makes the stored score derivable from stored evidence;
+  `signal` is that evidence.
+
+### Alternative 4: Backfill a separate pass that mines fallback fields for packages with no link
+
+- **Pros**: zero risk to the existing write paths; can be re-run at will.
+- **Cons**: a second code path that has to re-fetch or re-read every manifest,
+  and it goes stale the moment a package is re-ingested.
+- **Why not**: the data is already in hand at write time; the write path is
+  the cheapest place to fix coverage.
+
+## Consequences
+
+### Positive
+
+- Packages that only publish their repo in a secondary field now get a link,
+  and the link is honestly labelled as weaker.
+- The fallback order and the host gate exist once, so adding an ecosystem means
+  declaring a candidate list.
+- Per-run counters (`primary_field_hit`, `fallback_hit_by_field`, `no_signal`)
+  make the coverage uplift measurable against the pre-merge baseline.
+
+### Negative
+
+- Secondary links are, by construction, less certain than declared ones; some
+  will be wrong even with the host gate.
+- Maven and cargo needed local restructuring (maven onto the shared
+  canonicalizer, cargo's `repo_choice` in SQL) to reach the same behaviour.
+- Row counts in `package_repos` grow, and the dedup/keep-highest path now sees
+  more competing links per package.
+
+### Risks
+
+- **A secondary link can outrank a genuine one when the declared field is
+  missing on the true repo but present on a fork.** Mitigation: ADR-0020's
+  fork and archived penalties, plus ADR-0022's ownership evidence, which
+  penalises the fork's owner mismatch far more heavily than the secondary
+  penalty.
+- **Recognized-host gating rejects legitimate self-hosted repos found in a
+  fallback field.** Accepted deliberately: an unrecognized host in a free-form
+  field carries no signal that it is a repository at all. Revisit if the
+  `no_signal` counters show a material self-hosted tail.
+- **Coverage growth is hard to attribute after the fact.** Mitigation: record
+  per-ecosystem `package_repos` row counts before merge, and compare against
+  the `fallback_hit_by_field` counters afterwards.

--- a/docs/adr/0021-secondary-manifest-repository-signal.md
+++ b/docs/adr/0021-secondary-manifest-repository-signal.md
@@ -58,6 +58,32 @@ SQL over a dump, so `normalizeRepos` stages both `declared_repository_url` and
 first-wins-with-host-gate rule in SQL. `documentation` is not staged — it is
 almost always docs.rs, which the host gate rejects anyway.
 
+## Alternatives Considered
+
+### Per-ecosystem fallback (no shared helper)
+
+Each registry writer would duplicate its own fallback chain — npm already tried
+`bugs.url`, packagist already tried `homepage`.
+
+**Pros:** no new abstraction; each writer stays self-contained.
+**Cons:** seven writers meant seven copies of the same ordered-candidate logic
+and seven copies of the host-gate rule; adding a new ecosystem requires knowing
+which copy to follow.
+**Why not:** the duplication already caused drift (packagist's host gate existed
+alone; npm had no gate at all); a single helper enforces the rule once.
+
+### Accept all fallback fields at `primary` confidence
+
+Widen each writer to try secondary fields but record every link as `primary`.
+
+**Pros:** simpler persistence — no signal column needed.
+**Cons:** free-form fields (`homepage`, `projectUrl`) are noisy; ranking a
+documentation site equal to an explicit `<scm>` declaration inflates wrong
+links and corrupts the confidence score distribution.
+**Why not:** ADR-0020 already reserved the `signal` column and its −0.10 penalty
+specifically to express this distinction; a flat approach would abandon that
+mechanism before it could be used.
+
 ## Consequences
 
 ### Positive

--- a/docs/adr/0021-secondary-manifest-repository-signal.md
+++ b/docs/adr/0021-secondary-manifest-repository-signal.md
@@ -60,29 +60,40 @@ almost always docs.rs, which the host gate rejects anyway.
 
 ## Alternatives Considered
 
-### Per-ecosystem fallback (no shared helper)
+### Alternative 1: Widen each writer's existing extractor in place
 
-Each registry writer would duplicate its own fallback chain — npm already tried
-`bugs.url`, packagist already tried `homepage`.
+- **Pros**: no new module; smallest diff per ecosystem.
+- **Cons**: seven copies of the fallback order and the host gate, which is how
+  the current per-ecosystem divergence arose in the first place; the `signal`
+  value would be derived independently in each writer.
+- **Why not**: the whole point is one rule; nine implementations of "which
+  field won" is the defect, not the fix.
 
-**Pros:** no new abstraction; each writer stays self-contained.
-**Cons:** seven writers meant seven copies of the same ordered-candidate logic
-and seven copies of the host-gate rule; adding a new ecosystem requires knowing
-which copy to follow.
-**Why not:** the duplication already caused drift (packagist's host gate existed
-alone; npm had no gate at all); a single helper enforces the rule once.
+### Alternative 2: Accept fallback URLs on any host, like the primary field does
 
-### Accept all fallback fields at `primary` confidence
+- **Pros**: maximum coverage; no URL is discarded.
+- **Cons**: a documentation site or a marketing page with two path segments
+  becomes a repo link, creating a `repos` row and an incorrect
+  `packages_published` attribution — the exact failure this epic exists to fix.
+- **Why not**: coverage gained by inventing repos is negative value; the
+  primary field at least carries the publisher's explicit claim.
 
-Widen each writer to try secondary fields but record every link as `primary`.
+### Alternative 3: Score fallback links lower directly in the writers instead of adding `signal`
 
-**Pros:** simpler persistence — no signal column needed.
-**Cons:** free-form fields (`homepage`, `projectUrl`) are noisy; ranking a
-documentation site equal to an explicit `<scm>` declaration inflates wrong
-links and corrupts the confidence score distribution.
-**Why not:** ADR-0020 already reserved the `signal` column and its −0.10 penalty
-specifically to express this distinction; a flat approach would abandon that
-mechanism before it could be used.
+- **Pros**: no schema column; visible in one place.
+- **Cons**: reintroduces per-writer confidence literals, and the penalty could
+  not be retuned or audited afterwards — nothing records *why* a row scored
+  lower.
+- **Why not**: ADR-0020 makes the stored score derivable from stored evidence;
+  `signal` is that evidence.
+
+### Alternative 4: Backfill a separate pass that mines fallback fields for packages with no link
+
+- **Pros**: zero risk to the existing write paths; can be re-run at will.
+- **Cons**: a second code path that has to re-fetch or re-read every manifest,
+  and it goes stale the moment a package is re-ingested.
+- **Why not**: the data is already in hand at write time; the write path is
+  the cheapest place to fix coverage.
 
 ## Consequences
 

--- a/docs/adr/0021-secondary-manifest-repository-signal.md
+++ b/docs/adr/0021-secondary-manifest-repository-signal.md
@@ -33,15 +33,15 @@ returned `signal` on the link. No writer computes a confidence value.
 
 ### Chains
 
-| Ecosystem | Chain |
-| --- | --- |
-| npm | `repository` → `homepage` → `bugs.url` |
-| pypi | Source/Code project URL → `Homepage` → bug tracker URL |
-| cargo | `repository` → `homepage` |
-| rubygems | `source_code_uri` → `homepage_uri` → `bug_tracker_uri` |
-| packagist | `support.source` → `homepage` |
-| nuget | `<repository>` → `projectUrl` |
-| maven | POM `<scm><url>` → POM `<url>` |
+| Ecosystem | Chain                                                  |
+| --------- | ------------------------------------------------------ |
+| npm       | `repository` → `homepage` → `bugs.url`                 |
+| pypi      | Source/Code project URL → `Homepage` → bug tracker URL |
+| cargo     | `repository` → `homepage`                              |
+| rubygems  | `source_code_uri` → `homepage_uri` → `bug_tracker_uri` |
+| packagist | `support.source` → `homepage`                          |
+| nuget     | `<repository>` → `projectUrl`                          |
+| maven     | POM `<scm><url>` → POM `<url>`                         |
 
 ### Host gate
 
@@ -82,7 +82,7 @@ almost always docs.rs, which the host gate rejects anyway.
 
 - **Pros**: no schema column; visible in one place.
 - **Cons**: reintroduces per-writer confidence literals, and the penalty could
-  not be retuned or audited afterwards — nothing records *why* a row scored
+  not be retuned or audited afterwards — nothing records _why_ a row scored
   lower.
 - **Why not**: ADR-0020 makes the stored score derivable from stored evidence;
   `signal` is that evidence.
@@ -103,8 +103,8 @@ almost always docs.rs, which the host gate rejects anyway.
   and the link is honestly labelled as weaker.
 - The fallback order and the host gate exist once, so adding an ecosystem means
   declaring a candidate list.
-- Per-run counters (`primary_field_hit`, `fallback_hit_by_field`, `no_signal`)
-  make the coverage uplift measurable against the pre-merge baseline.
+- `package_repos.signal` is directly queryable (`GROUP BY signal`) after merge, making
+  the primary-vs-secondary coverage split measurable against the pre-merge baseline.
 
 ### Negative
 
@@ -125,8 +125,9 @@ almost always docs.rs, which the host gate rejects anyway.
   penalty.
 - **Recognized-host gating rejects legitimate self-hosted repos found in a
   fallback field.** Accepted deliberately: an unrecognized host in a free-form
-  field carries no signal that it is a repository at all. Revisit if the
-  `no_signal` counters show a material self-hosted tail.
+  field carries no signal that it is a repository at all. Rejected candidates
+  aren't persisted anywhere, so revisiting this needs an ad hoc sample of
+  homepage/bug_tracker fields against unrecognized hosts, not a live counter.
 - **Coverage growth is hard to attribute after the fact.** Mitigation: record
   per-ecosystem `package_repos` row counts before merge, and compare against
-  the `fallback_hit_by_field` counters afterwards.
+  post-merge `signal = 'secondary'` counts from the same table.

--- a/docs/adr/0021-secondary-manifest-repository-signal.md
+++ b/docs/adr/0021-secondary-manifest-repository-signal.md
@@ -16,10 +16,10 @@ that left the canonical field empty while publishing the same repo URL in
 repo link at all — invisible to criticality, blast radius, and Insights.
 
 Simply widening each writer to accept any of those fields would trade
-under-coverage for wrong links: fallback fields are free-form, so
+under-coverage for wrong links — fallback fields are free-form, so
 `https://example.com/docs/getting-started` canonicalizes into a plausible
-`owner/repo` shape without being a repository. Fallback links also should not
-rank equally with a declared one.
+`owner/repo` shape without being a repository — and shouldn't rank equally
+with a declared one anyway.
 [ADR-0020](./0020-package-repo-confidence-scoring.md) already reserved the
 `signal` column and its −0.10 penalty for exactly this.
 

--- a/docs/adr/0021-secondary-manifest-repository-signal.md
+++ b/docs/adr/0021-secondary-manifest-repository-signal.md
@@ -6,13 +6,14 @@
 
 ## Context
 
-Every registry writer only created a `package_repos` row when the ecosystem's
+Most registry writers only created a `package_repos` row when the ecosystem's
 canonical repository field parsed — npm `repository`, cargo `repository`,
-rubygems `source_code_uri`, NuGet `<repository>`, POM `<scm><url>`. A large
-share of packages leave that field empty while publishing the same repo URL in
-`homepage`, `bugs.url`, `projectUrl`, `bug_tracker_uri`, or the POM `<url>`, and
-those packages ended up with no repo link at all — invisible to criticality,
-blast radius, and Insights.
+rubygems `source_code_uri`, NuGet `<repository>`, POM `<scm><url>`. PyPI and
+NuGet already had ad hoc fallbacks onto `homepage`/`projectUrl`, but wrote them
+as `primary` with no record of which field won. Everywhere else, a package
+that left the canonical field empty while publishing the same repo URL in
+`homepage`, `bugs.url`, `bug_tracker_uri`, or the POM `<url>` ended up with no
+repo link at all — invisible to criticality, blast radius, and Insights.
 
 Simply widening each writer to accept any of those fields would trade
 under-coverage for wrong links: fallback fields are free-form, so
@@ -26,10 +27,8 @@ rank equally with a declared one.
 
 One shared helper, `resolveManifestRepo(candidates)`
 (`packages_worker/src/utils/resolveManifestRepo.ts`), resolves a package's repo
-from an ordered candidate list. The first candidate is the ecosystem's canonical
-field and resolves as `primary`; every later candidate resolves as `secondary`.
-The result carries `{ repo, signal }`, and each writer persists the
-returned `signal` on the link. No writer computes a confidence value.
+from an ordered candidate list — the first candidate is `primary`, every later
+one is `secondary` — and each writer persists the returned `signal` on the link.
 
 ### Chains
 

--- a/docs/adr/0021-secondary-manifest-repository-signal.md
+++ b/docs/adr/0021-secondary-manifest-repository-signal.md
@@ -119,10 +119,10 @@ almost always docs.rs, which the host gate rejects anyway.
 ### Risks
 
 - **A secondary link can outrank a genuine one when the declared field is
-  missing on the true repo but present on a fork.** Mitigation: ADR-0020's
-  fork and archived penalties, plus ADR-0022's ownership evidence, which
-  penalises the fork's owner mismatch far more heavily than the secondary
-  penalty.
+  missing on the true repo but present on a fork.** Currently mitigated only
+  by ADR-0020's fork and archived penalties. Ownership evidence that would
+  penalise the fork's owner mismatch far more heavily than the secondary
+  penalty is planned under CM-1394, not yet implemented.
 - **Recognized-host gating rejects legitimate self-hosted repos found in a
   fallback field.** Accepted deliberately: an unrecognized host in a free-form
   field carries no signal that it is a repository at all. Rejected candidates

--- a/docs/adr/0021-secondary-manifest-repository-signal.md
+++ b/docs/adr/0021-secondary-manifest-repository-signal.md
@@ -131,3 +131,13 @@ almost always docs.rs, which the host gate rejects anyway.
 - **Coverage growth is hard to attribute after the fact.** Mitigation: record
   per-ecosystem `package_repos` row counts before merge, and compare against
   post-merge `signal = 'secondary'` counts from the same table.
+- **Rows written by the pre-signal PyPI/NuGet fallback logic are backfilled as
+  `primary`, overstating their confidence until re-ingestion.** Accepted for
+  now: those packages get re-scored naturally on their next registry sync;
+  no separate backfill migration is planned.
+- **Maven's unchanged-version fast path (`runMavenEnrichmentLoop.ts`) skips
+  POM re-extraction, so a stable package already on the old writer never
+  gains a homepage-derived secondary link until it next changes version or a
+  forced full extraction runs.** Accepted: forcing full extraction for every
+  unchanged package on rollout would multiply POM-fetch volume; existing
+  packages backfill gradually as they publish new versions.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,7 @@ Use the `/adr` skill in Claude Code to record new ADRs or query past decisions.
 | [ADR-0018](./0018-per-client-rate-limiting-members-resolve.md) | Per-client rate limiting for `POST /members/resolve` using in-memory store                           | accepted | 2026-08-12 |
 | [ADR-0019](./0019-docker-builder-runner-libc.md)               | Same libc in Docker builder and runner                                                               | accepted | 2026-08-27 |
 | [ADR-0020](./0020-package-repo-confidence-scoring.md)          | Deterministic package→repo confidence scoring                                                        | accepted | 2026-09-01 |
+| [ADR-0021](./0021-secondary-manifest-repository-signal.md)     | Secondary manifest repository signal                                                                 | accepted | 2026-09-01 |
 
 ## Why ADRs?
 

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -201,15 +201,11 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
        SELECT (SELECT COUNT(*) FROM new_repos)::int AS repos`,
     )
 
-    // Prunes stale 'declared' links before relinking — covers junk/unparseable declared
-    // values, rewrites (declared URL now maps elsewhere), and removals (this dump's
-    // declared_repository_url is NULL, meaning the crate no longer declares a repo at
-    // all — loadDump.ts stages every matched crate every run, so NULL here is
-    // authoritative, not "no data this run"). Safe to always prune on that signal because
-    // the DELETE is scoped to source = 'declared' — cargo only ever removes links it owns.
-    // Without this, package_repos would accumulate a link to a repo no crate declares
-    // anymore, and consumers such as security-contacts (which join through
-    // repos ⋈ package_repos, not packages.repository_url) would keep reading it.
+    // Unconditionally prunes all cargo-owned declared links before relinking. Covers:
+    // removals (NULL in this dump is authoritative — loadDump stages every crate every run),
+    // URL rewrites, junk/unparseable values, and primary→secondary signal downgrades on the
+    // same URL (keep-highest would otherwise block the downgrade). Scoped to source =
+    // 'declared' so only cargo-owned rows are touched.
     const pruneRow = await tx.selectOne(
       `WITH targets AS (
          SELECT rc.package_id, r.id AS repo_id
@@ -221,7 +217,6 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
          USING targets t
          WHERE pr.package_id = t.package_id
            AND pr.source = $(source)
-           AND (t.repo_id IS NULL OR pr.repo_id IS DISTINCT FROM t.repo_id)
          RETURNING pr.package_id
        ),
        ins_audit AS (

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -70,8 +70,7 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            description             = COALESCE(e.description, p.description),
            homepage                = COALESCE(e.homepage, p.homepage),
            declared_repository_url = COALESCE(e.declared_repository_url, p.declared_repository_url),
-           repository_url          = CASE WHEN e.declared_repository_url IS NOT NULL OR rn.repository_url IS NOT NULL
-                                          THEN rn.repository_url ELSE p.repository_url END,
+           repository_url          = rn.repository_url,
            licenses                = COALESCE(e.licenses, p.licenses),
            licenses_raw            = COALESCE(e.licenses_raw, p.licenses_raw),
            keywords                = COALESCE(e.keywords, p.keywords),
@@ -99,9 +98,7 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            ('packages.description',             s.description             IS DISTINCT FROM COALESCE(e.description, s.description)),
            ('packages.homepage',                s.homepage                IS DISTINCT FROM COALESCE(e.homepage, s.homepage)),
            ('packages.declared_repository_url', s.declared_repository_url IS DISTINCT FROM COALESCE(e.declared_repository_url, s.declared_repository_url)),
-           ('packages.repository_url',          s.repository_url          IS DISTINCT FROM
-               CASE WHEN e.declared_repository_url IS NOT NULL OR rn.repository_url IS NOT NULL
-                    THEN rn.repository_url ELSE s.repository_url END),
+           ('packages.repository_url',          s.repository_url          IS DISTINCT FROM rn.repository_url),
            ('packages.licenses',                s.licenses                IS DISTINCT FROM COALESCE(e.licenses, s.licenses)),
            ('packages.licenses_raw',            s.licenses_raw            IS DISTINCT FROM COALESCE(e.licenses_raw, s.licenses_raw)),
            ('packages.keywords',                s.keywords                IS DISTINCT FROM COALESCE(e.keywords, s.keywords)),

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -70,7 +70,8 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            description             = COALESCE(e.description, p.description),
            homepage                = COALESCE(e.homepage, p.homepage),
            declared_repository_url = COALESCE(e.declared_repository_url, p.declared_repository_url),
-           repository_url          = rn.repository_url,
+           repository_url          = CASE WHEN e.declared_repository_url IS NOT NULL OR rn.repository_url IS NOT NULL
+                                         THEN rn.repository_url ELSE p.repository_url END,
            licenses                = COALESCE(e.licenses, p.licenses),
            licenses_raw            = COALESCE(e.licenses_raw, p.licenses_raw),
            keywords                = COALESCE(e.keywords, p.keywords),
@@ -98,7 +99,9 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            ('packages.description',             s.description             IS DISTINCT FROM COALESCE(e.description, s.description)),
            ('packages.homepage',                s.homepage                IS DISTINCT FROM COALESCE(e.homepage, s.homepage)),
            ('packages.declared_repository_url', s.declared_repository_url IS DISTINCT FROM COALESCE(e.declared_repository_url, s.declared_repository_url)),
-           ('packages.repository_url',          s.repository_url          IS DISTINCT FROM rn.repository_url),
+           ('packages.repository_url',          s.repository_url IS DISTINCT FROM
+              CASE WHEN e.declared_repository_url IS NOT NULL OR rn.repository_url IS NOT NULL
+                   THEN rn.repository_url ELSE s.repository_url END),
            ('packages.licenses',                s.licenses                IS DISTINCT FROM COALESCE(e.licenses, s.licenses)),
            ('packages.licenses_raw',            s.licenses_raw            IS DISTINCT FROM COALESCE(e.licenses_raw, s.licenses_raw)),
            ('packages.keywords',                s.keywords                IS DISTINCT FROM COALESCE(e.keywords, s.keywords)),

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -69,9 +69,9 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            status                  = e.status,
            description             = COALESCE(e.description, p.description),
            homepage                = COALESCE(e.homepage, p.homepage),
-           declared_repository_url = COALESCE(e.declared_repository_url, p.declared_repository_url),
-           -- repo_choice has exactly one unfiltered row per package_id, so rn.repository_url is
-           -- authoritative here — direct-assign (not COALESCE) to clear it when a package lost its repo.
+           -- The dump is authoritative for both fields — direct-assign (not COALESCE) so a
+           -- repository field or repo link dropped from the current dump actually clears here.
+           declared_repository_url = e.declared_repository_url,
            repository_url          = rn.repository_url,
            licenses                = COALESCE(e.licenses, p.licenses),
            licenses_raw            = COALESCE(e.licenses_raw, p.licenses_raw),
@@ -99,7 +99,7 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            ('packages.status',                  s.status                  IS DISTINCT FROM e.status),
            ('packages.description',             s.description             IS DISTINCT FROM COALESCE(e.description, s.description)),
            ('packages.homepage',                s.homepage                IS DISTINCT FROM COALESCE(e.homepage, s.homepage)),
-           ('packages.declared_repository_url', s.declared_repository_url IS DISTINCT FROM COALESCE(e.declared_repository_url, s.declared_repository_url)),
+           ('packages.declared_repository_url', s.declared_repository_url IS DISTINCT FROM e.declared_repository_url),
            ('packages.repository_url',          s.repository_url IS DISTINCT FROM rn.repository_url),
            ('packages.licenses',                s.licenses                IS DISTINCT FROM COALESCE(e.licenses, s.licenses)),
            ('packages.licenses_raw',            s.licenses_raw            IS DISTINCT FROM COALESCE(e.licenses_raw, s.licenses_raw)),

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -229,7 +229,7 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
 
     const linkRow = await tx.selectOne(
       `WITH old AS (
-         SELECT pr.package_id, pr.repo_id, pr.source, pr.confidence
+         SELECT pr.package_id, pr.repo_id, pr.source, pr.signal, pr.confidence
          FROM package_repos pr
          WHERE pr.package_id IN (
            SELECT package_id FROM ${STAGING_SCHEMA}.repo_choice WHERE repository_url IS NOT NULL
@@ -247,7 +247,7 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
          CROSS JOIN LATERAL (SELECT ${CARGO_CONFIDENCE} AS confidence) s
          ON CONFLICT (package_id, repo_id) DO UPDATE SET
            ${KEEP_HIGHEST_CONFLICT_UPDATE}
-         RETURNING package_id, repo_id, source, confidence
+         RETURNING package_id, repo_id, source, signal, confidence
        ),
        diff AS (
          SELECT ins.package_id, f.field
@@ -256,6 +256,7 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
          CROSS JOIN LATERAL (VALUES
            ('package_repos.repo_id',    o.repo_id IS NULL),
            ('package_repos.source',     o.repo_id IS NULL OR o.source     IS DISTINCT FROM ins.source),
+           ('package_repos.signal',     o.repo_id IS NULL OR o.signal     IS DISTINCT FROM ins.signal),
            ('package_repos.confidence', o.repo_id IS NULL OR o.confidence IS DISTINCT FROM ins.confidence)
          ) AS f(field, changed)
          WHERE f.changed

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -175,9 +175,8 @@ export async function enrichVersions(qx: QueryExecutor): Promise<EnrichVersionsR
   return { upserted: row.upserted }
 }
 
-// Writes only url + host — other repo fields belong to the GitHub enricher. Uses
-// repo_choice (built by normalizeRepos) so repos.url/package_repos always agree with
-// the canonical packages.repository_url — never the raw declared_repository_url.
+// Writes only url + host (other repo fields belong to the GitHub enricher), sourced from
+// repo_choice so repos/package_repos always agree with packages.repository_url, not the raw declared field.
 export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult> {
   return withTunedSession(qx, 'repos', async (tx) => {
     const repoRow = await tx.selectOne(

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -22,6 +22,7 @@ const INGESTION_SOURCE = 'cargo-registry'
 const REPO_LINK_SOURCE = 'declared' // same convention as npm/maven for manifest-declared repo URLs
 const CARGO_CONFIDENCE = packageRepoConfidenceCall('p', 'r', {
   source: '$(source)',
+  signal: 'rc.signal',
   provenance: 'NULL',
 })
 
@@ -69,7 +70,7 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            description             = COALESCE(e.description, p.description),
            homepage                = COALESCE(e.homepage, p.homepage),
            declared_repository_url = COALESCE(e.declared_repository_url, p.declared_repository_url),
-           repository_url          = CASE WHEN e.declared_repository_url IS NOT NULL
+           repository_url          = CASE WHEN e.declared_repository_url IS NOT NULL OR rn.repository_url IS NOT NULL
                                           THEN rn.repository_url ELSE p.repository_url END,
            licenses                = COALESCE(e.licenses, p.licenses),
            licenses_raw            = COALESCE(e.licenses_raw, p.licenses_raw),
@@ -84,7 +85,7 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            ingestion_source        = $(ingestionSource),
            last_synced_at          = NOW()
          FROM ${STAGING_SCHEMA}.enrich_packages e
-         LEFT JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
+         LEFT JOIN ${STAGING_SCHEMA}.repo_choice rn ON rn.package_id = e.package_id
          WHERE p.id = e.package_id
          RETURNING p.id
        ),
@@ -92,14 +93,15 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
          SELECT s.id AS package_id, f.field
          FROM snap s
          JOIN ${STAGING_SCHEMA}.enrich_packages e ON e.package_id = s.id
-         LEFT JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
+         LEFT JOIN ${STAGING_SCHEMA}.repo_choice rn ON rn.package_id = e.package_id
          CROSS JOIN LATERAL (VALUES
            ('packages.status',                  s.status                  IS DISTINCT FROM e.status),
            ('packages.description',             s.description             IS DISTINCT FROM COALESCE(e.description, s.description)),
            ('packages.homepage',                s.homepage                IS DISTINCT FROM COALESCE(e.homepage, s.homepage)),
            ('packages.declared_repository_url', s.declared_repository_url IS DISTINCT FROM COALESCE(e.declared_repository_url, s.declared_repository_url)),
            ('packages.repository_url',          s.repository_url          IS DISTINCT FROM
-               CASE WHEN e.declared_repository_url IS NOT NULL THEN rn.repository_url ELSE s.repository_url END),
+               CASE WHEN e.declared_repository_url IS NOT NULL OR rn.repository_url IS NOT NULL
+                    THEN rn.repository_url ELSE s.repository_url END),
            ('packages.licenses',                s.licenses                IS DISTINCT FROM COALESCE(e.licenses, s.licenses)),
            ('packages.licenses_raw',            s.licenses_raw            IS DISTINCT FROM COALESCE(e.licenses_raw, s.licenses_raw)),
            ('packages.keywords',                s.keywords                IS DISTINCT FROM COALESCE(e.keywords, s.keywords)),
@@ -175,25 +177,24 @@ export async function enrichVersions(qx: QueryExecutor): Promise<EnrichVersionsR
 }
 
 // Writes only url + host — other repo fields belong to the GitHub enricher. Uses
-// repo_norm (built by normalizeRepos) so repos.url/package_repos always agree with
+// repo_choice (built by normalizeRepos) so repos.url/package_repos always agree with
 // the canonical packages.repository_url — never the raw declared_repository_url.
 export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult> {
   return withTunedSession(qx, 'repos', async (tx) => {
     const repoRow = await tx.selectOne(
       `WITH new_repos AS (
          INSERT INTO repos (url, host, updated_at)
-         SELECT DISTINCT rn.repository_url, rn.host, NOW()
-         FROM ${STAGING_SCHEMA}.enrich_packages e
-         JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
+         SELECT DISTINCT rc.repository_url, rc.host, NOW()
+         FROM ${STAGING_SCHEMA}.repo_choice rc
+         WHERE rc.repository_url IS NOT NULL
          ON CONFLICT (url) DO NOTHING
          RETURNING url
        ),
        ins_audit AS (
          INSERT INTO ${STAGING_SCHEMA}.audit_changes (package_id, field)
-         SELECT e.package_id, f.field
-         FROM ${STAGING_SCHEMA}.enrich_packages e
-         JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
-         JOIN new_repos nr ON nr.url = rn.repository_url
+         SELECT rc.package_id, f.field
+         FROM ${STAGING_SCHEMA}.repo_choice rc
+         JOIN new_repos nr ON nr.url = rc.repository_url
          CROSS JOIN LATERAL (VALUES ('repos.url'), ('repos.host')) AS f(field)
          RETURNING 1
        )
@@ -211,10 +212,9 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
     // repos ⋈ package_repos, not packages.repository_url) would keep reading it.
     const pruneRow = await tx.selectOne(
       `WITH targets AS (
-         SELECT e.package_id, r.id AS repo_id
-         FROM ${STAGING_SCHEMA}.enrich_packages e
-         LEFT JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
-         LEFT JOIN repos r ON r.url = rn.repository_url
+         SELECT rc.package_id, r.id AS repo_id
+         FROM ${STAGING_SCHEMA}.repo_choice rc
+         LEFT JOIN repos r ON r.url = rc.repository_url
        ),
        del AS (
          DELETE FROM package_repos pr
@@ -240,19 +240,18 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
          SELECT pr.package_id, pr.repo_id, pr.source, pr.confidence
          FROM package_repos pr
          WHERE pr.package_id IN (
-           SELECT package_id FROM ${STAGING_SCHEMA}.enrich_packages WHERE declared_repository_url IS NOT NULL
+           SELECT package_id FROM ${STAGING_SCHEMA}.repo_choice WHERE repository_url IS NOT NULL
          )
        ),
        ins AS (
          INSERT INTO package_repos (
-           package_id, repo_id, source, provenance, confidence, created_at, verified_at
+           package_id, repo_id, source, signal, provenance, confidence, created_at, verified_at
          )
-         SELECT e.package_id, r.id, $(source), NULL,
+         SELECT rc.package_id, r.id, $(source), rc.signal, NULL,
                 s.confidence, NOW(), NOW()
-         FROM ${STAGING_SCHEMA}.enrich_packages e
-         JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
-         JOIN repos r ON r.url = rn.repository_url
-         JOIN packages p ON p.id = e.package_id
+         FROM ${STAGING_SCHEMA}.repo_choice rc
+         JOIN repos r ON r.url = rc.repository_url
+         JOIN packages p ON p.id = rc.package_id
          CROSS JOIN LATERAL (SELECT ${CARGO_CONFIDENCE} AS confidence) s
          ON CONFLICT (package_id, repo_id) DO UPDATE SET
            ${KEEP_HIGHEST_CONFLICT_UPDATE}

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -70,8 +70,11 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            description             = COALESCE(e.description, p.description),
            homepage                = COALESCE(e.homepage, p.homepage),
            declared_repository_url = COALESCE(e.declared_repository_url, p.declared_repository_url),
-           repository_url          = CASE WHEN e.declared_repository_url IS NOT NULL OR rn.repository_url IS NOT NULL
-                                         THEN rn.repository_url ELSE p.repository_url END,
+           -- repo_choice has exactly one row per package_id in enrich_packages (a plain FROM,
+           -- never filtered), so rn.repository_url is authoritative for this run — direct-assign
+           -- it (not COALESCE) so a package that lost its repo in this dump has the denormalized
+           -- column cleared consistently with enrichRepos' unconditional package_repos prune.
+           repository_url          = rn.repository_url,
            licenses                = COALESCE(e.licenses, p.licenses),
            licenses_raw            = COALESCE(e.licenses_raw, p.licenses_raw),
            keywords                = COALESCE(e.keywords, p.keywords),
@@ -99,9 +102,7 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            ('packages.description',             s.description             IS DISTINCT FROM COALESCE(e.description, s.description)),
            ('packages.homepage',                s.homepage                IS DISTINCT FROM COALESCE(e.homepage, s.homepage)),
            ('packages.declared_repository_url', s.declared_repository_url IS DISTINCT FROM COALESCE(e.declared_repository_url, s.declared_repository_url)),
-           ('packages.repository_url',          s.repository_url IS DISTINCT FROM
-              CASE WHEN e.declared_repository_url IS NOT NULL OR rn.repository_url IS NOT NULL
-                   THEN rn.repository_url ELSE s.repository_url END),
+           ('packages.repository_url',          s.repository_url IS DISTINCT FROM rn.repository_url),
            ('packages.licenses',                s.licenses                IS DISTINCT FROM COALESCE(e.licenses, s.licenses)),
            ('packages.licenses_raw',            s.licenses_raw            IS DISTINCT FROM COALESCE(e.licenses_raw, s.licenses_raw)),
            ('packages.keywords',                s.keywords                IS DISTINCT FROM COALESCE(e.keywords, s.keywords)),
@@ -201,11 +202,12 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
        SELECT (SELECT COUNT(*) FROM new_repos)::int AS repos`,
     )
 
-    // Unconditionally prunes all cargo-owned declared links before relinking. Covers:
-    // removals (NULL in this dump is authoritative — loadDump stages every crate every run),
-    // URL rewrites, junk/unparseable values, and primary→secondary signal downgrades on the
-    // same URL (keep-highest would otherwise block the downgrade). Scoped to source =
-    // 'declared' so only cargo-owned rows are touched.
+    // Prunes cargo-owned declared links whose target changed since the last run: removals
+    // (NULL in this dump is authoritative — loadDump stages every crate every run), URL
+    // rewrites, and junk/unparseable values. An unchanged link is left alone so the upsert
+    // below's ON CONFLICT ... KEEP_HIGHEST_CONFLICT_UPDATE handles same-repo signal/confidence
+    // changes (e.g. a primary→secondary downgrade) without a delete+reinsert. Scoped to
+    // source = 'declared' so only cargo-owned rows are touched.
     const pruneRow = await tx.selectOne(
       `WITH targets AS (
          SELECT rc.package_id, r.id AS repo_id
@@ -217,6 +219,7 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
          USING targets t
          WHERE pr.package_id = t.package_id
            AND pr.source = $(source)
+           AND pr.repo_id IS DISTINCT FROM t.repo_id
          RETURNING pr.package_id
        ),
        ins_audit AS (

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -70,10 +70,8 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            description             = COALESCE(e.description, p.description),
            homepage                = COALESCE(e.homepage, p.homepage),
            declared_repository_url = COALESCE(e.declared_repository_url, p.declared_repository_url),
-           -- repo_choice has exactly one row per package_id in enrich_packages (a plain FROM,
-           -- never filtered), so rn.repository_url is authoritative for this run — direct-assign
-           -- it (not COALESCE) so a package that lost its repo in this dump has the denormalized
-           -- column cleared consistently with enrichRepos' unconditional package_repos prune.
+           -- repo_choice has exactly one unfiltered row per package_id, so rn.repository_url is
+           -- authoritative here — direct-assign (not COALESCE) to clear it when a package lost its repo.
            repository_url          = rn.repository_url,
            licenses                = COALESCE(e.licenses, p.licenses),
            licenses_raw            = COALESCE(e.licenses_raw, p.licenses_raw),
@@ -202,12 +200,8 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
        SELECT (SELECT COUNT(*) FROM new_repos)::int AS repos`,
     )
 
-    // Prunes cargo-owned declared links whose target changed since the last run: removals
-    // (NULL in this dump is authoritative — loadDump stages every crate every run), URL
-    // rewrites, and junk/unparseable values. An unchanged link is left alone so the upsert
-    // below's ON CONFLICT ... KEEP_HIGHEST_CONFLICT_UPDATE handles same-repo signal/confidence
-    // changes (e.g. a primary→secondary downgrade) without a delete+reinsert. Scoped to
-    // source = 'declared' so only cargo-owned rows are touched.
+    // Prunes declared links whose target changed (removed, rewritten, or unparseable); an
+    // unchanged link is left for the upsert's KEEP_HIGHEST_CONFLICT_UPDATE to handle in place.
     const pruneRow = await tx.selectOne(
       `WITH targets AS (
          SELECT rc.package_id, r.id AS repo_id

--- a/services/apps/packages_worker/src/cargo/normalizeRepos.ts
+++ b/services/apps/packages_worker/src/cargo/normalizeRepos.ts
@@ -11,29 +11,6 @@ const log = getServiceChildLogger('cargo-normalize')
 // Batch size for the mapping upsert — keeps parameter arrays well under Postgres limits.
 const INSERT_BATCH = 5000
 
-/**
- * Builds `cargo_sync.repo_norm(declared, repository_url, host)`, mapping every
- * distinct `declared_repository_url` and `homepage` staged in `enrich_packages` to its canonical
- * `https://<host>/<owner>/<name>` form via the shared `canonicalizeRepoUrl`
- * (same normalizer npm/pypi use — no per-ecosystem fork).
- *
- * Only inputs `canonicalizeRepoUrl` can reduce to an owner/name pair are stored;
- * unparseable URLs or those with fewer than two path segments are omitted, so a
- * LEFT JOIN from `enrich_packages` yields NULL — that both recovers derivable
- * URLs (Gap A) and clears that class of junk from `packages.repository_url`
- * (Gap C). Note this does not validate that the result is an actual repository
- * host — a URL-shaped homepage with ≥2 path segments (e.g.
- * `https://example.com/owner/repo`) still canonicalizes and is stored.
- *
- * `cargo_sync.repo_choice` then picks one repo per crate: the declared `repository`
- * field (`primary`) or, when that is absent or unparseable, the `homepage` — accepted
- * only on a recognized VCS host, since a homepage is free-form. `documentation` is not
- * staged from the dump and is almost always docs.rs, which that gate rejects anyway.
- *
- * Normalization runs in TypeScript because the bulk set-based cargo pipeline
- * cannot call the parser per row; the resulting mapping table lets the SQL
- * enrich phases join back to it. Idempotent: the table is rebuilt each run.
- */
 export async function normalizeRepos(qx: QueryExecutor): Promise<NormalizeReposResult> {
   const rows: Array<{ url: string }> = await qx.select(
     `SELECT DISTINCT declared_repository_url AS url

--- a/services/apps/packages_worker/src/cargo/normalizeRepos.ts
+++ b/services/apps/packages_worker/src/cargo/normalizeRepos.ts
@@ -13,7 +13,7 @@ const INSERT_BATCH = 5000
 
 /**
  * Builds `cargo_sync.repo_norm(declared, repository_url, host)`, mapping every
- * distinct `declared_repository_url` staged in `enrich_packages` to its canonical
+ * distinct `declared_repository_url` and `homepage` staged in `enrich_packages` to its canonical
  * `https://<host>/<owner>/<name>` form via the shared `canonicalizeRepoUrl`
  * (same normalizer npm/pypi use — no per-ecosystem fork).
  *
@@ -25,15 +25,24 @@ const INSERT_BATCH = 5000
  * host — a URL-shaped homepage with ≥2 path segments (e.g.
  * `https://example.com/owner/repo`) still canonicalizes and is stored.
  *
+ * `cargo_sync.repo_choice` then picks one repo per crate: the declared `repository`
+ * field (`primary`) or, when that is absent or unparseable, the `homepage` — accepted
+ * only on a recognized VCS host, since a homepage is free-form. `documentation` is not
+ * staged from the dump and is almost always docs.rs, which that gate rejects anyway.
+ *
  * Normalization runs in TypeScript because the bulk set-based cargo pipeline
  * cannot call the parser per row; the resulting mapping table lets the SQL
  * enrich phases join back to it. Idempotent: the table is rebuilt each run.
  */
 export async function normalizeRepos(qx: QueryExecutor): Promise<NormalizeReposResult> {
-  const rows: Array<{ declared_repository_url: string }> = await qx.select(
-    `SELECT DISTINCT declared_repository_url
+  const rows: Array<{ url: string }> = await qx.select(
+    `SELECT DISTINCT declared_repository_url AS url
        FROM ${STAGING_SCHEMA}.enrich_packages
-      WHERE declared_repository_url IS NOT NULL`,
+      WHERE declared_repository_url IS NOT NULL
+     UNION
+     SELECT DISTINCT homepage AS url
+       FROM ${STAGING_SCHEMA}.enrich_packages
+      WHERE homepage IS NOT NULL`,
   )
 
   await qx.result(
@@ -46,9 +55,9 @@ export async function normalizeRepos(qx: QueryExecutor): Promise<NormalizeReposR
   )
 
   const mapped = rows
-    .map(({ declared_repository_url }) => ({
-      declared: declared_repository_url,
-      canonical: canonicalizeRepoUrl(declared_repository_url),
+    .map(({ url }) => ({
+      declared: url,
+      canonical: canonicalizeRepoUrl(url),
     }))
     .filter((r): r is { declared: string; canonical: CanonicalRepo } => r.canonical !== null)
 
@@ -66,7 +75,29 @@ export async function normalizeRepos(qx: QueryExecutor): Promise<NormalizeReposR
     )
   }
 
-  const result: NormalizeReposResult = { scanned: rows.length, normalized: mapped.length }
+  await qx.result(
+    `DROP TABLE IF EXISTS ${STAGING_SCHEMA}.repo_choice CASCADE;
+     CREATE TABLE ${STAGING_SCHEMA}.repo_choice AS
+     SELECT e.package_id,
+            COALESCE(rd.repository_url, rh.repository_url) AS repository_url,
+            COALESCE(rd.host, rh.host)                     AS host,
+            CASE WHEN rd.repository_url IS NOT NULL THEN 'primary' ELSE 'secondary' END AS signal
+     FROM ${STAGING_SCHEMA}.enrich_packages e
+     LEFT JOIN ${STAGING_SCHEMA}.repo_norm rd ON rd.declared = e.declared_repository_url
+     LEFT JOIN ${STAGING_SCHEMA}.repo_norm rh ON rh.declared = e.homepage AND rh.host <> 'other';
+     CREATE INDEX ON ${STAGING_SCHEMA}.repo_choice (package_id)`,
+  )
+
+  const choiceRow = await qx.selectOne(
+    `SELECT COUNT(*) FILTER (WHERE repository_url IS NOT NULL AND signal = 'secondary')::int AS fallbacks
+       FROM ${STAGING_SCHEMA}.repo_choice`,
+  )
+
+  const result: NormalizeReposResult = {
+    scanned: rows.length,
+    normalized: mapped.length,
+    homepageFallbacks: choiceRow.fallbacks,
+  }
   log.info(result, 'cargo repo normalization complete')
   return result
 }

--- a/services/apps/packages_worker/src/cargo/types.ts
+++ b/services/apps/packages_worker/src/cargo/types.ts
@@ -15,6 +15,7 @@ export interface LoadResult {
 export interface NormalizeReposResult {
   scanned: number
   normalized: number
+  homepageFallbacks: number
 }
 
 export interface EnrichPackagesResult {

--- a/services/apps/packages_worker/src/deps-dev/workflows/ingestRepos.ts
+++ b/services/apps/packages_worker/src/deps-dev/workflows/ingestRepos.ts
@@ -111,10 +111,10 @@ WITH github_staged AS MATERIALIZED (
   WHERE r2.host = 'github'
 )
 INSERT INTO package_repos (
-  package_id, repo_id, source, provenance, confidence, verified_at, created_at
+  package_id, repo_id, source, signal, provenance, confidence, verified_at, created_at
 )
 SELECT DISTINCT ON (p.id, r.id)
-  p.id, r.id, 'deps_dev', s.provenance,
+  p.id, r.id, 'deps_dev', 'primary', s.provenance,
   c.confidence, NOW(), NOW()
 FROM staging.osspckgs_package_repos_raw s
 JOIN packages p ON p.purl = REGEXP_REPLACE(s.purl, '@[^@]+$', '')
@@ -125,6 +125,7 @@ CROSS JOIN LATERAL (
     'r',
     {
       source: `'deps_dev'`,
+      signal: `'primary'`,
       provenance: 's.provenance',
     },
     `((r.host <> 'github' AND EXISTS (SELECT 1 FROM github_staged gs WHERE gs.package_id = p.id)) OR ${competingGithubRepoExpr('p.id', 'r.id')})`,

--- a/services/apps/packages_worker/src/maven/backfillRepositoryUrl.ts
+++ b/services/apps/packages_worker/src/maven/backfillRepositoryUrl.ts
@@ -4,8 +4,11 @@ import {
   rescorePackageReposForPackages,
   updateMavenRepositoryUrls,
 } from '@crowd/data-access-layer'
+import { PackageRepoSignal } from '@crowd/data-access-layer/src/packages/repoConfidence'
 import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 import { getServiceChildLogger } from '@crowd/logging'
+
+import { resolveManifestRepo } from '../utils/resolveManifestRepo'
 
 import { normalizeScmUrl } from './extract'
 import { withDeadlockRetry, writeRepoLink } from './runMavenEnrichmentLoop'
@@ -24,9 +27,11 @@ export type RepoUrlBackfillTotals = {
 
 /**
  * Recomputes `repository_url` for every Maven row directly from the stored
- * `declared_repository_url`, applying the current `normalizeScmUrl`. No POMs are
- * fetched — the raw SCM value is already in the DB. Fills recoverable NULLs
- * (Gap B) and clears non-repository values (Gap C) via direct UPDATE.
+ * `declared_repository_url`, applying the current `normalizeScmUrl` — falling back to
+ * the stored `homepage` as a secondary signal when the declared value doesn't
+ * canonicalize, same as the enrichment loop. No POMs are fetched — the raw values are
+ * already in the DB. Fills recoverable NULLs (Gap B) and clears non-repository values
+ * with no usable fallback (Gap C) via direct UPDATE.
  *
  * Link tables: package_repos is kept consistent with the recomputed
  * repository_url. For rows that had a value and now change (rewrites) or are
@@ -79,10 +84,17 @@ export async function backfillMavenRepositoryUrls(
     // Rows that had a link and now change/clear — their stale 'declared' link is pruned.
     const pruneTargets: number[] = []
     // Rows that gained a canonical URL — their repo link is (re)written after the update.
-    const linkTargets: { id: number; repositoryUrl: string }[] = []
+    const linkTargets: { id: number; repositoryUrl: string; signal: PackageRepoSignal }[] = []
     for (const row of rows) {
       totals.scanned++
-      const desired = normalizeScmUrl(row.declaredRepositoryUrl)
+      const scmRepositoryUrl = normalizeScmUrl(row.declaredRepositoryUrl)
+      // A non-canonical declared value falls back to homepage, same as the enrichment
+      // loop — otherwise this recompute wipes a homepage-derived secondary link on a
+      // rerun (the stored declared_repository_url alone can't tell "unknown" from "invalid").
+      const fallbackRepo = scmRepositoryUrl
+        ? null
+        : resolveManifestRepo([{ field: 'url', url: row.homepage, signal: 'secondary' }])
+      const desired = scmRepositoryUrl ?? fallbackRepo?.repo.url ?? null
       if (desired === row.repositoryUrl) {
         totals.unchanged++
         continue
@@ -93,7 +105,13 @@ export async function backfillMavenRepositoryUrls(
       updates.push({ id: row.id, repositoryUrl: desired })
       // A 'declared' link only exists when the row already had a value.
       if (row.repositoryUrl !== null) pruneTargets.push(row.id)
-      if (desired !== null) linkTargets.push({ id: row.id, repositoryUrl: desired })
+      if (desired !== null) {
+        linkTargets.push({
+          id: row.id,
+          repositoryUrl: desired,
+          signal: fallbackRepo ? 'secondary' : 'primary',
+        })
+      }
     }
 
     if (updates.length > 0 && !dryRun) {
@@ -109,7 +127,7 @@ export async function backfillMavenRepositoryUrls(
           await deleteMavenPackageRepoLinks(t, pruneTargets)
           await rescorePackageReposForPackages(t, pruneTargets.map(String))
           for (const target of linkTargets) {
-            await writeRepoLink(t, target.id, target.repositoryUrl)
+            await writeRepoLink(t, target.id, target.repositoryUrl, undefined, target.signal)
           }
         }),
       )

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -4,6 +4,7 @@ import {
   listMavenCriticalPackagesById,
   listMavenPackagesToSync,
   logAuditFieldChange,
+  removeDeclaredPackageRepo,
   replacePackageMaintainers,
   touchPackageSyncedAt,
   upsertMaintainer,
@@ -57,12 +58,22 @@ type PackageRow = MavenPackageToSync
 
 // prettier-ignore
 export async function writeRepoLink(qx: QueryExecutor, packageId: number, repositoryUrl: string | null, changed?: Set<string>, signal: PackageRepoSignal = 'primary'): Promise<void> {
-  if (!repositoryUrl) return
+  if (!repositoryUrl) {
+    const removedFields = await removeDeclaredPackageRepo(qx, String(packageId))
+    removedFields.forEach((f) => changed?.add(f))
+    return
+  }
   const parsed = parseRepoUrl(repositoryUrl)
-  if (!parsed) return
+  if (!parsed) {
+    const removedFields = await removeDeclaredPackageRepo(qx, String(packageId))
+    removedFields.forEach((f) => changed?.add(f))
+    return
+  }
   const repoId = await upsertRepo(qx, { url: repositoryUrl, ...parsed })
   const repoChanged = await upsertPackageRepo(qx, String(packageId), String(repoId), { source: 'declared', signal })
   repoChanged.forEach((f) => changed?.add(f))
+  const removedFields = await removeDeclaredPackageRepo(qx, String(packageId), String(repoId))
+  removedFields.forEach((f) => changed?.add(f))
 }
 
 // Postgres deadlock (40P01) is transient: concurrent transactions upserting the same shared

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -12,9 +12,11 @@ import {
   upsertRepo,
   upsertVersionsBatch,
 } from '@crowd/data-access-layer'
+import type { PackageRepoSignal } from '@crowd/data-access-layer/src/packages/repoConfidence'
 import { getServiceChildLogger } from '@crowd/logging'
 
 import { getMavenConfig } from '../config'
+import { resolveManifestRepo } from '../utils/resolveManifestRepo'
 
 import { extractArtifact, getPomCacheStats, normalizeScmUrl } from './extract'
 import { isMavenFetchError, resolveVersionsList } from './metadata'
@@ -54,12 +56,12 @@ type PackageRow = MavenPackageToSync
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 // prettier-ignore
-export async function writeRepoLink(qx: QueryExecutor, packageId: number, repositoryUrl: string | null, changed?: Set<string>): Promise<void> {
+export async function writeRepoLink(qx: QueryExecutor, packageId: number, repositoryUrl: string | null, changed?: Set<string>, signal: PackageRepoSignal = 'primary'): Promise<void> {
   if (!repositoryUrl) return
   const parsed = parseRepoUrl(repositoryUrl)
   if (!parsed) return
   const repoId = await upsertRepo(qx, { url: repositoryUrl, ...parsed })
-  const repoChanged = await upsertPackageRepo(qx, String(packageId), String(repoId), { source: 'declared' })
+  const repoChanged = await upsertPackageRepo(qx, String(packageId), String(repoId), { source: 'declared', signal })
   repoChanged.forEach((f) => changed?.add(f))
 }
 
@@ -261,7 +263,11 @@ async function processCriticalPackage(qx: QueryExecutor, pkg: PackageRow, forceF
     return { status: 'error' }
   }
 
-  const repositoryUrl = normalizeScmUrl(result.scmUrl)
+  const scmRepositoryUrl = normalizeScmUrl(result.scmUrl)
+  const fallbackRepo = scmRepositoryUrl
+    ? null
+    : resolveManifestRepo([{ field: 'url', url: result.homepageUrl, signal: 'secondary' }])
+  const repositoryUrl = scmRepositoryUrl ?? fallbackRepo?.repo.url ?? null
 
   await withDeadlockRetry(() =>
     qx.tx(async (t: QueryExecutor) => {
@@ -335,7 +341,7 @@ async function processCriticalPackage(qx: QueryExecutor, pkg: PackageRow, forceF
         pmChanged.forEach((f) => changed.add(f))
       }
 
-      await writeRepoLink(t, packageId, repositoryUrl, changed)
+      await writeRepoLink(t, packageId, repositoryUrl, changed, fallbackRepo ? 'secondary' : 'primary')
 
       await logAuditFieldChange(t, 'maven', pkg.purl, Array.from(changed))
 

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -358,9 +358,8 @@ async function processCriticalPackage(qx: QueryExecutor, pkg: PackageRow, forceF
         pmChanged.forEach((f) => changed.add(f))
       }
 
-      // upsertPackage's COALESCE can't tell "POM dropped <scm><url>" from "unknown" — this
-      // path is a successful full POM extraction, so result.scmUrl is authoritative; clear
-      // declared_repository_url explicitly when it's gone.
+      // upsertPackage's COALESCE can't distinguish a dropped <scm><url> from "unknown" — this
+      // POM extraction succeeded, so clear declared_repository_url explicitly when it's gone.
       const declaredClearedFields = await setPackageDeclaredRepositoryUrl(
         t,
         packageId.toString(),

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -6,6 +6,7 @@ import {
   logAuditFieldChange,
   removeDeclaredPackageRepo,
   replacePackageMaintainers,
+  setPackageRepositoryUrl,
   touchPackageSyncedAt,
   upsertMaintainer,
   upsertPackage,
@@ -61,12 +62,16 @@ export async function writeRepoLink(qx: QueryExecutor, packageId: number, reposi
   if (!repositoryUrl) {
     const removedFields = await removeDeclaredPackageRepo(qx, String(packageId))
     removedFields.forEach((f) => changed?.add(f))
+    const clearedFields = await setPackageRepositoryUrl(qx, String(packageId), null)
+    clearedFields.forEach((f) => changed?.add(f))
     return
   }
   const parsed = parseRepoUrl(repositoryUrl)
   if (!parsed) {
     const removedFields = await removeDeclaredPackageRepo(qx, String(packageId))
     removedFields.forEach((f) => changed?.add(f))
+    const clearedFields = await setPackageRepositoryUrl(qx, String(packageId), null)
+    clearedFields.forEach((f) => changed?.add(f))
     return
   }
   const repoId = await upsertRepo(qx, { url: repositoryUrl, ...parsed })

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -6,6 +6,7 @@ import {
   logAuditFieldChange,
   removeDeclaredPackageRepo,
   replacePackageMaintainers,
+  setPackageDeclaredRepositoryUrl,
   setPackageRepositoryUrl,
   touchPackageSyncedAt,
   upsertMaintainer,
@@ -356,6 +357,16 @@ async function processCriticalPackage(qx: QueryExecutor, pkg: PackageRow, forceF
         const pmChanged = await replacePackageMaintainers(t, packageId, maintainerLinks)
         pmChanged.forEach((f) => changed.add(f))
       }
+
+      // upsertPackage's COALESCE can't tell "POM dropped <scm><url>" from "unknown" — this
+      // path is a successful full POM extraction, so result.scmUrl is authoritative; clear
+      // declared_repository_url explicitly when it's gone.
+      const declaredClearedFields = await setPackageDeclaredRepositoryUrl(
+        t,
+        packageId.toString(),
+        result.scmUrl,
+      )
+      declaredClearedFields.forEach((f) => changed.add(f))
 
       await writeRepoLink(t, packageId, repositoryUrl, changed, fallbackRepo ? 'secondary' : 'primary')
 

--- a/services/apps/packages_worker/src/npm/normalize.ts
+++ b/services/apps/packages_worker/src/npm/normalize.ts
@@ -1,5 +1,4 @@
-import { canonicalizeRepoUrl } from '../utils/canonicalizeRepoUrl'
-import type { CanonicalRepo } from '../utils/canonicalizeRepoUrl'
+import { ResolvedManifestRepo, resolveManifestRepo } from '../utils/resolveManifestRepo'
 
 import type { Packument } from './types'
 
@@ -70,12 +69,24 @@ function dedup(arr: string[]): string[] {
   return [...new Set(arr)]
 }
 
-export function extractRepo(packument: Packument): CanonicalRepo | null {
+export function npmRepositoryField(packument: Packument): string | null {
   const repo = packument.repository
   if (!repo) return null
-  const raw = typeof repo === 'string' ? repo : repo.url
-  if (!raw) return null
-  return canonicalizeRepoUrl(raw)
+  return (typeof repo === 'string' ? repo : repo.url) || null
+}
+
+function npmBugsUrl(packument: Packument): string | null {
+  const bugs = packument.bugs
+  if (!bugs) return null
+  return (typeof bugs === 'string' ? bugs : bugs.url) || null
+}
+
+export function resolveNpmRepo(packument: Packument): ResolvedManifestRepo | null {
+  return resolveManifestRepo([
+    { field: 'repository', url: npmRepositoryField(packument) },
+    { field: 'homepage', url: packument.homepage },
+    { field: 'bugs.url', url: npmBugsUrl(packument) },
+  ])
 }
 
 export function collectMaintainers(packument: Packument): Array<{

--- a/services/apps/packages_worker/src/npm/types.ts
+++ b/services/apps/packages_worker/src/npm/types.ts
@@ -16,6 +16,7 @@ export interface Packument {
   license?: string | { type: string; url?: string }
   licenses?: Array<{ type: string; url?: string }>
   repository?: string | { type?: string; url: string; directory?: string }
+  bugs?: string | { url?: string; email?: string }
   author?: string | { name: string; email?: string; url?: string }
   maintainers?: Array<{ name: string; email?: string }>
   'dist-tags': Record<string, string>

--- a/services/apps/packages_worker/src/npm/upsertPackage.ts
+++ b/services/apps/packages_worker/src/npm/upsertPackage.ts
@@ -1,5 +1,6 @@
 import {
   getOrCreateRepoByUrl,
+  removeDeclaredPackageRepo,
   upsertNpmFundingLinks,
   upsertNpmPackage,
   upsertNpmVersions,
@@ -94,6 +95,12 @@ export async function upsertPackage(
         signal: resolvedRepo.signal,
       })
       linkChanged.forEach((f) => changed.add(f))
+
+      const removedFields = await removeDeclaredPackageRepo(t, pkgId, repoId)
+      removedFields.forEach((f) => changed.add(f))
+    } else {
+      const removedFields = await removeDeclaredPackageRepo(t, pkgId)
+      removedFields.forEach((f) => changed.add(f))
     }
 
     const verChanged = await upsertNpmVersions(

--- a/services/apps/packages_worker/src/npm/upsertPackage.ts
+++ b/services/apps/packages_worker/src/npm/upsertPackage.ts
@@ -12,10 +12,11 @@ import { stripNullBytesDeep } from '../utils/stripNullBytesDeep'
 
 import {
   collectMaintainers,
-  extractRepo,
   isPrerelease,
   normalizeLicenses,
+  npmRepositoryField,
   parseNpmName,
+  resolveNpmRepo,
   versionLicense,
 } from './normalize'
 import type { FundingEntry, Packument } from './types'
@@ -36,9 +37,9 @@ export async function upsertPackage(
   const { namespace, name } = parseNpmName(raw)
   const licenses = normalizeLicenses(packument)
   const licensesRaw = typeof packument.license === 'string' ? packument.license : null
-  const declaredRepositoryUrl = rawRepoUrl(packument)
-  const repo = extractRepo(packument)
-  const repositoryUrl = repo?.url ?? null
+  const declaredRepositoryUrl = npmRepositoryField(packument)
+  const resolvedRepo = resolveNpmRepo(packument)
+  const repositoryUrl = resolvedRepo?.repo.url ?? null
   const versionEntries = Object.entries(packument.versions)
   const time = packument.time ?? {}
   const latestVersion = packument['dist-tags']?.latest ?? null
@@ -80,15 +81,18 @@ export async function upsertPackage(
     })
     pkgChanged.forEach((f) => changed.add(f))
 
-    if (repo) {
+    if (resolvedRepo) {
       const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(
         t,
-        repo.url,
-        repo.host,
+        resolvedRepo.repo.url,
+        resolvedRepo.repo.host,
       )
       repoChanged.forEach((f) => changed.add(f))
 
-      const linkChanged = await upsertPackageRepo(t, pkgId, repoId, { source: 'declared' })
+      const linkChanged = await upsertPackageRepo(t, pkgId, repoId, {
+        source: 'declared',
+        signal: resolvedRepo.signal,
+      })
       linkChanged.forEach((f) => changed.add(f))
     }
 
@@ -123,12 +127,6 @@ function cleanKeywords(raw: unknown): string[] | null {
   if (!Array.isArray(raw)) return null
   const cleaned = raw.filter((k): k is string => typeof k === 'string' && k.trim() !== '')
   return cleaned.length > 0 ? cleaned : null
-}
-
-function rawRepoUrl(packument: Packument): string | null {
-  const repo = packument.repository
-  if (!repo) return null
-  return typeof repo === 'string' ? repo || null : repo.url || null
 }
 
 function extractFundingLinks(

--- a/services/apps/packages_worker/src/nuget/normalize.ts
+++ b/services/apps/packages_worker/src/nuget/normalize.ts
@@ -1,6 +1,6 @@
 import { XMLParser } from 'fast-xml-parser'
 
-import { canonicalizeRepoUrl } from '../utils/canonicalizeRepoUrl'
+import { resolveManifestRepo } from '../utils/resolveManifestRepo'
 
 import {
   NormalizedNuGetPackage,
@@ -39,17 +39,6 @@ export function parseNuspecRepositoryUrl(nuspecXml: string): string | null {
     return typeof url === 'string' && url.trim() !== '' ? url.trim() : null
   } catch {
     return null
-  }
-}
-
-const SCM_HOSTS = ['github.com', 'gitlab.com', 'bitbucket.org']
-
-function isScmUrl(url: string | undefined): boolean {
-  if (!url) return false
-  try {
-    return SCM_HOSTS.some((h) => new URL(url).hostname.endsWith(h))
-  } catch {
-    return false
   }
 }
 
@@ -95,7 +84,6 @@ export function normalizeNuGetPackage(
   const homepage = searchResult?.projectUrl || latestListedEntry?.projectUrl || null
 
   // Scan all entries (prefer latest listed, then any) for a nuspec <repository> url.
-  // Fall back to a SCM-shaped projectUrl/homepage when no nuspec repository is present.
   const entriesForRepo = latestListedEntry
     ? [
         latestListedEntry,
@@ -107,9 +95,10 @@ export function normalizeNuGetPackage(
   const fetchedNuspecRepoUrl = nuspecXml ? parseNuspecRepositoryUrl(nuspecXml) : null
   const nuspecRepoUrl = fetchedNuspecRepoUrl ?? catalogRepoUrl
   const declaredRepositoryUrl = nuspecRepoUrl ?? null
-  const repo =
-    (nuspecRepoUrl ? canonicalizeRepoUrl(nuspecRepoUrl) : null) ??
-    (isScmUrl(homepage) ? canonicalizeRepoUrl(homepage) : null)
+  const resolvedRepo = resolveManifestRepo([
+    { field: 'repository', url: nuspecRepoUrl },
+    { field: 'projectUrl', url: homepage },
+  ])
 
   const keywords = searchResult?.tags && searchResult.tags.length > 0 ? searchResult.tags : null
 
@@ -164,7 +153,7 @@ export function normalizeNuGetPackage(
     description,
     homepage: homepage || null,
     declaredRepositoryUrl,
-    repo,
+    resolvedRepo,
     licenses,
     licensesRaw,
     keywords,

--- a/services/apps/packages_worker/src/nuget/normalize.ts
+++ b/services/apps/packages_worker/src/nuget/normalize.ts
@@ -97,9 +97,8 @@ export function normalizeNuGetPackage(
   const fetchedNuspecRepoUrl = nuspecXml ? parseNuspecRepositoryUrl(nuspecXml) : null
   const nuspecRepoUrl = fetchedNuspecRepoUrl ?? catalogRepoUrl
   const declaredRepositoryUrl = nuspecRepoUrl ?? null
-  // searchResult.projectUrl and the catalog's projectUrl are passed as separate candidates
-  // (not collapsed via the `homepage` fallback above) so a non-repo search result doesn't
-  // mask a repo-looking catalog projectUrl at the host gate.
+  // Passed as separate candidates so a non-repo search projectUrl can't mask
+  // a repo-looking catalog projectUrl at the host gate.
   const resolvedRepo = resolveManifestRepo([
     { field: 'repository', url: nuspecRepoUrl },
     { field: 'projectUrl', url: searchProjectUrl },

--- a/services/apps/packages_worker/src/nuget/normalize.ts
+++ b/services/apps/packages_worker/src/nuget/normalize.ts
@@ -95,12 +95,12 @@ export function normalizeNuGetPackage(
     : [...allEntries].reverse()
   const catalogRepoUrl = entriesForRepo.find((e) => e.repository?.url)?.repository?.url
   const fetchedNuspecRepoUrl = nuspecXml ? parseNuspecRepositoryUrl(nuspecXml) : null
-  const nuspecRepoUrl = fetchedNuspecRepoUrl ?? catalogRepoUrl
-  const declaredRepositoryUrl = nuspecRepoUrl ?? null
-  // Passed as separate candidates so a non-repo search projectUrl can't mask
-  // a repo-looking catalog projectUrl at the host gate.
+  const declaredRepositoryUrl = fetchedNuspecRepoUrl ?? catalogRepoUrl ?? null
+  // Passed as separate candidates so a non-repo search projectUrl, or a malformed
+  // fetched nuspec URL, can't mask a repo-looking catalog value at the host gate.
   const resolvedRepo = resolveManifestRepo([
-    { field: 'repository', url: nuspecRepoUrl },
+    { field: 'repository', url: fetchedNuspecRepoUrl, signal: 'primary' },
+    { field: 'repository', url: catalogRepoUrl, signal: 'primary' },
     { field: 'projectUrl', url: searchProjectUrl },
     { field: 'projectUrl', url: catalogProjectUrl },
   ])

--- a/services/apps/packages_worker/src/nuget/normalize.ts
+++ b/services/apps/packages_worker/src/nuget/normalize.ts
@@ -81,7 +81,9 @@ export function normalizeNuGetPackage(
   const description =
     searchResult?.description || searchResult?.summary || latestListedEntry?.description || null
 
-  const homepage = searchResult?.projectUrl || latestListedEntry?.projectUrl || null
+  const searchProjectUrl = searchResult?.projectUrl || null
+  const catalogProjectUrl = latestListedEntry?.projectUrl || null
+  const homepage = searchProjectUrl || catalogProjectUrl
 
   // Scan all entries (prefer latest listed, then any) for a nuspec <repository> url.
   const entriesForRepo = latestListedEntry
@@ -95,9 +97,13 @@ export function normalizeNuGetPackage(
   const fetchedNuspecRepoUrl = nuspecXml ? parseNuspecRepositoryUrl(nuspecXml) : null
   const nuspecRepoUrl = fetchedNuspecRepoUrl ?? catalogRepoUrl
   const declaredRepositoryUrl = nuspecRepoUrl ?? null
+  // searchResult.projectUrl and the catalog's projectUrl are passed as separate candidates
+  // (not collapsed via the `homepage` fallback above) so a non-repo search result doesn't
+  // mask a repo-looking catalog projectUrl at the host gate.
   const resolvedRepo = resolveManifestRepo([
     { field: 'repository', url: nuspecRepoUrl },
-    { field: 'projectUrl', url: homepage },
+    { field: 'projectUrl', url: searchProjectUrl },
+    { field: 'projectUrl', url: catalogProjectUrl },
   ])
 
   const keywords = searchResult?.tags && searchResult.tags.length > 0 ? searchResult.tags : null

--- a/services/apps/packages_worker/src/nuget/normalize.ts
+++ b/services/apps/packages_worker/src/nuget/normalize.ts
@@ -93,14 +93,17 @@ export function normalizeNuGetPackage(
         ...(latestEntry ? [latestEntry] : []),
       ]
     : [...allEntries].reverse()
-  const catalogRepoUrl = entriesForRepo.find((e) => e.repository?.url)?.repository?.url
+  const catalogRepoUrls = entriesForRepo
+    .map((e) => e.repository?.url)
+    .filter((url): url is string => !!url)
+  const catalogRepoUrl = catalogRepoUrls[0] ?? null
   const fetchedNuspecRepoUrl = nuspecXml ? parseNuspecRepositoryUrl(nuspecXml) : null
   const declaredRepositoryUrl = fetchedNuspecRepoUrl ?? catalogRepoUrl ?? null
-  // Passed as separate candidates so a non-repo search projectUrl, or a malformed
-  // fetched nuspec URL, can't mask a repo-looking catalog value at the host gate.
+  // Every catalog entry's url is passed through, not just the latest — a malformed one
+  // is dropped at canonicalization, so an older entry's valid url still gets tried.
   const resolvedRepo = resolveManifestRepo([
     { field: 'repository', url: fetchedNuspecRepoUrl, signal: 'primary' },
-    { field: 'repository', url: catalogRepoUrl, signal: 'primary' },
+    ...catalogRepoUrls.map((url) => ({ field: 'repository', url, signal: 'primary' as const })),
     { field: 'projectUrl', url: searchProjectUrl },
     { field: 'projectUrl', url: catalogProjectUrl },
   ])

--- a/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
@@ -7,6 +7,7 @@ import {
   logAuditFieldChange,
   markNuGetPackageError,
   recordNuGetDownloadSnapshot,
+  removeDeclaredPackageRepo,
   replacePackageMaintainers,
   upsertMaintainer,
   upsertNuGetPackage,
@@ -145,6 +146,12 @@ async function processPackage(
           signal: normalized.resolvedRepo.signal,
         })
         linkChanged.forEach((f) => changed.add(f))
+
+        const removedFields = await removeDeclaredPackageRepo(t, packageDbId.toString(), repoId)
+        removedFields.forEach((f) => changed.add(f))
+      } else {
+        const removedFields = await removeDeclaredPackageRepo(t, packageDbId.toString())
+        removedFields.forEach((f) => changed.add(f))
       }
 
       if (normalized.versions.length > 0) {

--- a/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
@@ -118,7 +118,7 @@ async function processPackage(
         description: normalized.description,
         homepage: normalized.homepage,
         declaredRepositoryUrl: normalized.declaredRepositoryUrl,
-        repositoryUrl: normalized.repo?.url ?? null,
+        repositoryUrl: normalized.resolvedRepo?.repo.url ?? null,
         licenses: normalized.licenses,
         licensesRaw: normalized.licensesRaw,
         keywords: normalized.keywords,
@@ -132,16 +132,17 @@ async function processPackage(
       })
       pkgChanged.forEach((f) => changed.add(f))
 
-      if (normalized.repo) {
+      if (normalized.resolvedRepo) {
         const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(
           t,
-          normalized.repo.url,
-          normalized.repo.host,
+          normalized.resolvedRepo.repo.url,
+          normalized.resolvedRepo.repo.host,
         )
         repoChanged.forEach((f) => changed.add(f))
 
         const linkChanged = await upsertPackageRepo(t, packageDbId.toString(), repoId, {
           source: 'declared',
+          signal: normalized.resolvedRepo.signal,
         })
         linkChanged.forEach((f) => changed.add(f))
       }

--- a/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
@@ -9,6 +9,7 @@ import {
   recordNuGetDownloadSnapshot,
   removeDeclaredPackageRepo,
   replacePackageMaintainers,
+  setPackageRepositoryUrl,
   upsertMaintainer,
   upsertNuGetPackage,
   upsertNuGetVersionsBatch,
@@ -152,6 +153,8 @@ async function processPackage(
       } else {
         const removedFields = await removeDeclaredPackageRepo(t, packageDbId.toString())
         removedFields.forEach((f) => changed.add(f))
+        const clearedFields = await setPackageRepositoryUrl(t, packageDbId.toString(), null)
+        clearedFields.forEach((f) => changed.add(f))
       }
 
       if (normalized.versions.length > 0) {

--- a/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
@@ -160,9 +160,8 @@ async function processPackage(
         declaredClearedFields.forEach((f) => changed.add(f))
       }
 
-      // repoUnknown means the only thing standing between "resolved" and "absent" is a
-      // transient rate limit — reconciling now would downgrade or delete a link that's
-      // still valid.
+      // repoUnknown: only a transient rate limit separates "resolved" from "absent" here —
+      // reconciling now would downgrade or delete a link that's still valid.
       if (!repoUnknown) {
         if (normalized.resolvedRepo) {
           const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(

--- a/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
@@ -125,7 +125,9 @@ async function processPackage(
         description: normalized.description,
         homepage: normalized.homepage,
         declaredRepositoryUrl: normalized.declaredRepositoryUrl,
-        repositoryUrl: normalized.resolvedRepo?.repo.url ?? null,
+        // null on a rate-limited nuspec fetch — the DAL coalesces null to the stored value,
+        // so an unknown nuspec-repo result can't be overwritten by a lower-trust fallback.
+        repositoryUrl: nuspecRateLimited ? null : (normalized.resolvedRepo?.repo.url ?? null),
         licenses: normalized.licenses,
         licensesRaw: normalized.licensesRaw,
         keywords: normalized.keywords,

--- a/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
@@ -116,10 +116,11 @@ async function processPackage(
   }
 
   const normalized = normalizeNuGetPackage(packageId, searchItem, registrationResult, nuspecXml)
-  // A rate-limited search only breaks resolution when nothing else resolved a repo — if a
-  // nuspec/catalog result won independently, the missing search projectUrl candidate never
-  // mattered.
-  const repoUnknown = nuspecRateLimited || (searchRateLimited && !normalized.resolvedRepo)
+  // A rate-limited search only breaks resolution when the missing search projectUrl could
+  // still have outranked the winner — only a primary (repository/nuspec) candidate proves
+  // it couldn't, since projectUrl-tier candidates are ordered right after it.
+  const repoUnknown =
+    nuspecRateLimited || (searchRateLimited && normalized.resolvedRepo?.signal !== 'primary')
 
   await withDeadlockRetry(() =>
     qx.tx(async (t) => {

--- a/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
@@ -103,9 +103,14 @@ async function processPackage(
   const preliminary = normalizeNuGetPackage(packageId, searchItem, registrationResult)
 
   let nuspecXml: string | null = null
+  let nuspecRateLimited = false
   if (preliminary.latestVersion) {
     const nuspecResult = await fetchNuspec(packageId, preliminary.latestVersion)
-    nuspecXml = isNuGetFetchError(nuspecResult) ? null : nuspecResult
+    if (isNuGetFetchError(nuspecResult)) {
+      nuspecRateLimited = nuspecResult.kind === 'RATE_LIMIT'
+    } else {
+      nuspecXml = nuspecResult
+    }
   }
 
   const normalized = normalizeNuGetPackage(packageId, searchItem, registrationResult, nuspecXml)
@@ -134,27 +139,31 @@ async function processPackage(
       })
       pkgChanged.forEach((f) => changed.add(f))
 
-      if (normalized.resolvedRepo) {
-        const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(
-          t,
-          normalized.resolvedRepo.repo.url,
-          normalized.resolvedRepo.repo.host,
-        )
-        repoChanged.forEach((f) => changed.add(f))
+      // A rate-limited nuspec fetch means the nuspec-only repo candidate is unknown, not
+      // absent — reconciling now would downgrade or delete a link that's still valid.
+      if (!nuspecRateLimited) {
+        if (normalized.resolvedRepo) {
+          const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(
+            t,
+            normalized.resolvedRepo.repo.url,
+            normalized.resolvedRepo.repo.host,
+          )
+          repoChanged.forEach((f) => changed.add(f))
 
-        const linkChanged = await upsertPackageRepo(t, packageDbId.toString(), repoId, {
-          source: 'declared',
-          signal: normalized.resolvedRepo.signal,
-        })
-        linkChanged.forEach((f) => changed.add(f))
+          const linkChanged = await upsertPackageRepo(t, packageDbId.toString(), repoId, {
+            source: 'declared',
+            signal: normalized.resolvedRepo.signal,
+          })
+          linkChanged.forEach((f) => changed.add(f))
 
-        const removedFields = await removeDeclaredPackageRepo(t, packageDbId.toString(), repoId)
-        removedFields.forEach((f) => changed.add(f))
-      } else {
-        const removedFields = await removeDeclaredPackageRepo(t, packageDbId.toString())
-        removedFields.forEach((f) => changed.add(f))
-        const clearedFields = await setPackageRepositoryUrl(t, packageDbId.toString(), null)
-        clearedFields.forEach((f) => changed.add(f))
+          const removedFields = await removeDeclaredPackageRepo(t, packageDbId.toString(), repoId)
+          removedFields.forEach((f) => changed.add(f))
+        } else {
+          const removedFields = await removeDeclaredPackageRepo(t, packageDbId.toString())
+          removedFields.forEach((f) => changed.add(f))
+          const clearedFields = await setPackageRepositoryUrl(t, packageDbId.toString(), null)
+          clearedFields.forEach((f) => changed.add(f))
+        }
       }
 
       if (normalized.versions.length > 0) {

--- a/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
@@ -9,6 +9,7 @@ import {
   recordNuGetDownloadSnapshot,
   removeDeclaredPackageRepo,
   replacePackageMaintainers,
+  setPackageDeclaredRepositoryUrl,
   setPackageRepositoryUrl,
   upsertMaintainer,
   upsertNuGetPackage,
@@ -124,9 +125,9 @@ async function processPackage(
         name: pkg.name,
         description: normalized.description,
         homepage: normalized.homepage,
-        declaredRepositoryUrl: normalized.declaredRepositoryUrl,
         // null on a rate-limited nuspec fetch — the DAL coalesces null to the stored value,
         // so an unknown nuspec-repo result can't be overwritten by a lower-trust fallback.
+        declaredRepositoryUrl: nuspecRateLimited ? null : normalized.declaredRepositoryUrl,
         repositoryUrl: nuspecRateLimited ? null : (normalized.resolvedRepo?.repo.url ?? null),
         licenses: normalized.licenses,
         licensesRaw: normalized.licensesRaw,
@@ -144,6 +145,15 @@ async function processPackage(
       // A rate-limited nuspec fetch means the nuspec-only repo candidate is unknown, not
       // absent — reconciling now would downgrade or delete a link that's still valid.
       if (!nuspecRateLimited) {
+        // upsertNuGetPackage's COALESCE can't tell "no declared repo this pass" from
+        // "unknown" — clear it explicitly so a dropped declaration doesn't stick around.
+        const declaredClearedFields = await setPackageDeclaredRepositoryUrl(
+          t,
+          packageDbId.toString(),
+          normalized.declaredRepositoryUrl,
+        )
+        declaredClearedFields.forEach((f) => changed.add(f))
+
         if (normalized.resolvedRepo) {
           const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(
             t,

--- a/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/nuget/runNuGetEnrichmentLoop.ts
@@ -99,6 +99,7 @@ async function processPackage(
     )
   }
 
+  const searchRateLimited = isNuGetFetchError(searchResult) && searchResult.kind === 'RATE_LIMIT'
   const searchItem = isNuGetFetchError(searchResult) ? null : searchResult
 
   const preliminary = normalizeNuGetPackage(packageId, searchItem, registrationResult)
@@ -115,6 +116,10 @@ async function processPackage(
   }
 
   const normalized = normalizeNuGetPackage(packageId, searchItem, registrationResult, nuspecXml)
+  // A rate-limited search only breaks resolution when nothing else resolved a repo — if a
+  // nuspec/catalog result won independently, the missing search projectUrl candidate never
+  // mattered.
+  const repoUnknown = nuspecRateLimited || (searchRateLimited && !normalized.resolvedRepo)
 
   await withDeadlockRetry(() =>
     qx.tx(async (t) => {
@@ -128,7 +133,7 @@ async function processPackage(
         // null on a rate-limited nuspec fetch — the DAL coalesces null to the stored value,
         // so an unknown nuspec-repo result can't be overwritten by a lower-trust fallback.
         declaredRepositoryUrl: nuspecRateLimited ? null : normalized.declaredRepositoryUrl,
-        repositoryUrl: nuspecRateLimited ? null : (normalized.resolvedRepo?.repo.url ?? null),
+        repositoryUrl: repoUnknown ? null : (normalized.resolvedRepo?.repo.url ?? null),
         licenses: normalized.licenses,
         licensesRaw: normalized.licensesRaw,
         keywords: normalized.keywords,
@@ -153,7 +158,12 @@ async function processPackage(
           normalized.declaredRepositoryUrl,
         )
         declaredClearedFields.forEach((f) => changed.add(f))
+      }
 
+      // repoUnknown means the only thing standing between "resolved" and "absent" is a
+      // transient rate limit — reconciling now would downgrade or delete a link that's
+      // still valid.
+      if (!repoUnknown) {
         if (normalized.resolvedRepo) {
           const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(
             t,

--- a/services/apps/packages_worker/src/nuget/types.ts
+++ b/services/apps/packages_worker/src/nuget/types.ts
@@ -1,4 +1,4 @@
-import { CanonicalRepo } from '../utils/canonicalizeRepoUrl'
+import { ResolvedManifestRepo } from '../utils/resolveManifestRepo'
 
 export interface NuGetConfig {
   batchSize: number
@@ -75,7 +75,7 @@ export interface NormalizedNuGetPackage {
   description: string | null
   homepage: string | null
   declaredRepositoryUrl: string | null
-  repo: CanonicalRepo | null
+  resolvedRepo: ResolvedManifestRepo | null
   licenses: string[] | null
   licensesRaw: string | null
   keywords: string[] | null

--- a/services/apps/packages_worker/src/packagist/__tests__/dueSelection.test.ts
+++ b/services/apps/packages_worker/src/packagist/__tests__/dueSelection.test.ts
@@ -225,6 +225,7 @@ describe('updatePackagistPackageStats', () => {
     qx.selectOneOrNone.mockResolvedValue({
       id: '7',
       is_critical: true,
+      homepage: null,
       changed_fields: ['packages.description'],
     })
 
@@ -241,6 +242,7 @@ describe('updatePackagistPackageStats', () => {
     expect(result).toEqual({
       id: '7',
       isCritical: true,
+      homepage: null,
       changedFields: ['packages.description'],
     })
   })

--- a/services/apps/packages_worker/src/packagist/__tests__/dueSelection.test.ts
+++ b/services/apps/packages_worker/src/packagist/__tests__/dueSelection.test.ts
@@ -225,7 +225,6 @@ describe('updatePackagistPackageStats', () => {
     qx.selectOneOrNone.mockResolvedValue({
       id: '7',
       is_critical: true,
-      homepage: null,
       changed_fields: ['packages.description'],
     })
 
@@ -242,7 +241,6 @@ describe('updatePackagistPackageStats', () => {
     expect(result).toEqual({
       id: '7',
       isCritical: true,
-      homepage: null,
       changedFields: ['packages.description'],
     })
   })

--- a/services/apps/packages_worker/src/packagist/__tests__/ingest.test.ts
+++ b/services/apps/packages_worker/src/packagist/__tests__/ingest.test.ts
@@ -25,7 +25,7 @@ import { fetchPackagistP2, fetchPackagistStats } from '../fetchPackage'
 import { fetchPackagistPackageList, parsePackagistPackageList } from '../listPackages'
 import { INGEST_MAX_ATTEMPTS } from '../retryPolicy'
 import { persistPackagistMetadata } from '../upsertMetadata'
-import { persistPackagistPackageInfo } from '../upsertPackageInfo'
+import { persistPackagistPackageInfo, reconcilePackagistHomepageRepo } from '../upsertPackageInfo'
 
 // Mock the heavy collaborators so we exercise the classification/retry/give-up logic.
 vi.mock('../fetchPackage', () => ({
@@ -33,7 +33,10 @@ vi.mock('../fetchPackage', () => ({
   fetchPackagistP2: vi.fn(),
   buildPackagistUserAgent: vi.fn(() => 'ua'),
 }))
-vi.mock('../upsertPackageInfo', () => ({ persistPackagistPackageInfo: vi.fn() }))
+vi.mock('../upsertPackageInfo', () => ({
+  persistPackagistPackageInfo: vi.fn(),
+  reconcilePackagistHomepageRepo: vi.fn().mockResolvedValue([]),
+}))
 vi.mock('../upsertMetadata', () => ({ persistPackagistMetadata: vi.fn() }))
 vi.mock('../downloads', () => ({
   monthlyWindowFor: vi.fn(),
@@ -61,6 +64,7 @@ const mockFetchStats = vi.mocked(fetchPackagistStats)
 const mockFetchP2 = vi.mocked(fetchPackagistP2)
 const mockExpand = vi.mocked(expandComposerMetadata)
 const mockPersistInfo = vi.mocked(persistPackagistPackageInfo)
+const mockReconcileHomepageRepo = vi.mocked(reconcilePackagistHomepageRepo)
 const mockPersistMetadata = vi.mocked(persistPackagistMetadata)
 const mockPersist30d = vi.mocked(persistPackagist30dWindow)
 const mockDaily = vi.mocked(insertDailyDownloads)
@@ -100,7 +104,12 @@ describe('ingestOnePackagistMetadata', () => {
 
   function happyMocks() {
     mockFetchStats.mockResolvedValue(statsJson as never)
-    mockPersistInfo.mockResolvedValue({ found: true, changedFields: ['packages.description'] })
+    mockPersistInfo.mockResolvedValue({
+      found: true,
+      changedFields: ['packages.description'],
+      packageId: '1',
+      hasPrimaryRepo: true,
+    })
     mockFetchP2.mockResolvedValue({
       minifiedVersions: minified,
       lastModified: 'Wed, 01 Jul 2026 00:00:00 GMT',
@@ -110,6 +119,7 @@ describe('ingestOnePackagistMetadata', () => {
       found: true,
       changedFields: ['versions.number'],
       unresolvedDependencyTargets: 0,
+      homepage: null,
     })
   }
 
@@ -131,6 +141,39 @@ describe('ingestOnePackagistMetadata', () => {
       expect.objectContaining({ status: 'success', attempts: 1 }),
       { metadataLastModified: 'Wed, 01 Jul 2026 00:00:00 GMT' },
     )
+  })
+
+  it('reconciles the homepage-fallback repo from the fresh p2 homepage when phase 1 had no primary repo', async () => {
+    happyMocks()
+    mockPersistInfo.mockResolvedValue({
+      found: true,
+      changedFields: ['packages.description'],
+      packageId: '1',
+      hasPrimaryRepo: false,
+    })
+    mockPersistMetadata.mockResolvedValue({
+      found: true,
+      changedFields: ['versions.number'],
+      unresolvedDependencyTargets: 0,
+      homepage: 'https://github.com/monolog/monolog',
+    })
+
+    await ingestOnePackagistMetadata(qx, candidate, SCHEDULED_AT)
+
+    expect(mockReconcileHomepageRepo).toHaveBeenCalledWith(
+      qx,
+      PURL,
+      '1',
+      'https://github.com/monolog/monolog',
+    )
+  })
+
+  it('skips homepage reconciliation when phase 1 already resolved a primary repo', async () => {
+    happyMocks()
+
+    await ingestOnePackagistMetadata(qx, candidate, SCHEDULED_AT)
+
+    expect(mockReconcileHomepageRepo).not.toHaveBeenCalled()
   })
 
   it('records a p2 NOT_MODIFIED as success: info persisted, versions skipped', async () => {
@@ -188,7 +231,12 @@ describe('ingestOnePackagistMetadata', () => {
   it('gives up on a persistent p2 404 after fast retries and marks it scanned(error)', async () => {
     vi.useFakeTimers()
     mockFetchStats.mockResolvedValue(statsJson as never)
-    mockPersistInfo.mockResolvedValue({ found: true, changedFields: [] })
+    mockPersistInfo.mockResolvedValue({
+      found: true,
+      changedFields: [],
+      packageId: '1',
+      hasPrimaryRepo: true,
+    })
     mockFetchP2.mockResolvedValue({
       kind: 'NOT_FOUND',
       statusCode: 404,
@@ -215,7 +263,12 @@ describe('ingestOnePackagistMetadata', () => {
     // itself before the p2 fetch (which can throw) ever runs — see persistPackageInfo.test.ts
     vi.useFakeTimers()
     mockFetchStats.mockResolvedValue(statsJson as never)
-    mockPersistInfo.mockResolvedValue({ found: true, changedFields: ['packages.description'] })
+    mockPersistInfo.mockResolvedValue({
+      found: true,
+      changedFields: ['packages.description'],
+      packageId: '1',
+      hasPrimaryRepo: true,
+    })
     mockFetchP2.mockResolvedValue({
       kind: 'NOT_FOUND',
       statusCode: 404,
@@ -237,7 +290,12 @@ describe('ingestOnePackagistMetadata', () => {
 
   it('throws on a transient p2 result without marking scanned, but phase 1 already persisted', async () => {
     mockFetchStats.mockResolvedValue(statsJson as never)
-    mockPersistInfo.mockResolvedValue({ found: true, changedFields: ['packages.description'] })
+    mockPersistInfo.mockResolvedValue({
+      found: true,
+      changedFields: ['packages.description'],
+      packageId: '1',
+      hasPrimaryRepo: true,
+    })
     mockFetchP2.mockResolvedValue({ kind: 'TRANSIENT', message: 'HTTP 502' } as never)
 
     await expect(ingestOnePackagistMetadata(qx, candidate, SCHEDULED_AT)).rejects.toThrow()

--- a/services/apps/packages_worker/src/packagist/__tests__/persistMetadata.test.ts
+++ b/services/apps/packages_worker/src/packagist/__tests__/persistMetadata.test.ts
@@ -60,7 +60,11 @@ beforeEach(() => {
 // resolved to existing packages rows only.
 describe('persistPackagistMetadata', () => {
   it('upserts version rows (dev branches excluded), aggregates, and resolved dependency edges', async () => {
-    mockAggregates.mockResolvedValue({ id: '9', changedFields: ['packages.latest_version'] })
+    mockAggregates.mockResolvedValue({
+      id: '9',
+      changedFields: ['packages.latest_version'],
+      homepage: 'https://monolog.example.org',
+    })
     mockVersions.mockResolvedValue({
       changedFields: ['versions.number'],
       versionIds: [
@@ -133,7 +137,11 @@ describe('persistPackagistMetadata', () => {
   })
 
   it('skips and counts dependency targets that do not resolve to a packages row', async () => {
-    mockAggregates.mockResolvedValue({ id: '9', changedFields: [] })
+    mockAggregates.mockResolvedValue({
+      id: '9',
+      changedFields: [],
+      homepage: 'https://monolog.example.org',
+    })
     mockVersions.mockResolvedValue({
       changedFields: [],
       versionIds: [
@@ -153,7 +161,7 @@ describe('persistPackagistMetadata', () => {
   })
 
   it('reconciles (deletes stale edges) even when a version now declares zero dependencies', async () => {
-    mockAggregates.mockResolvedValue({ id: '9', changedFields: [] })
+    mockAggregates.mockResolvedValue({ id: '9', changedFields: [], homepage: null })
     mockVersions.mockResolvedValue({
       changedFields: [],
       versionIds: [{ number: '1.0.0', id: '20' }],
@@ -180,7 +188,7 @@ describe('persistPackagistMetadata', () => {
       found: false,
       changedFields: [],
       unresolvedDependencyTargets: 0,
-      homepage: 'https://monolog.example.org',
+      homepage: null,
     })
     expect(mockVersions).not.toHaveBeenCalled()
     expect(mockIds).not.toHaveBeenCalled()
@@ -189,7 +197,7 @@ describe('persistPackagistMetadata', () => {
   })
 
   it('handles a dev-branches-only package: aggregates written, no version or dependency writes', async () => {
-    mockAggregates.mockResolvedValue({ id: '9', changedFields: [] })
+    mockAggregates.mockResolvedValue({ id: '9', changedFields: [], homepage: null })
 
     const result = await persistPackagistMetadata(qx, PURL, [
       { version: 'dev-main', version_normalized: 'dev-main' },
@@ -205,8 +213,30 @@ describe('persistPackagistMetadata', () => {
     expect(result.found).toBe(true)
   })
 
+  it('returns the effective persisted homepage, not the raw candidate, when COALESCE retains the old value', async () => {
+    // updatePackagistVersionAggregates COALESCEs homepage — an omitted p2 field (null
+    // candidate) does NOT clear a previously-stored homepage. The caller reconciles the
+    // secondary repo link from this result, so it must reflect what's actually on the row.
+    mockAggregates.mockResolvedValue({
+      id: '9',
+      changedFields: [],
+      homepage: 'https://old.example.org',
+    })
+    mockVersions.mockResolvedValue({ changedFields: [], versionIds: [] })
+
+    const result = await persistPackagistMetadata(qx, PURL, [
+      { version: '1.0.0', version_normalized: '1.0.0.0' },
+    ])
+
+    expect(result.homepage).toBe('https://old.example.org')
+  })
+
   it('strips NUL bytes from the homepage before writing (Postgres rejects them)', async () => {
-    mockAggregates.mockResolvedValue({ id: '9', changedFields: [] })
+    mockAggregates.mockResolvedValue({
+      id: '9',
+      changedFields: [],
+      homepage: 'https://example.org',
+    })
     mockVersions.mockResolvedValue({ changedFields: [], versionIds: [] })
 
     await persistPackagistMetadata(qx, PURL, [

--- a/services/apps/packages_worker/src/packagist/__tests__/persistMetadata.test.ts
+++ b/services/apps/packages_worker/src/packagist/__tests__/persistMetadata.test.ts
@@ -176,7 +176,12 @@ describe('persistPackagistMetadata', () => {
 
     const result = await persistPackagistMetadata(qx, PURL, expanded)
 
-    expect(result).toEqual({ found: false, changedFields: [], unresolvedDependencyTargets: 0 })
+    expect(result).toEqual({
+      found: false,
+      changedFields: [],
+      unresolvedDependencyTargets: 0,
+      homepage: 'https://monolog.example.org',
+    })
     expect(mockVersions).not.toHaveBeenCalled()
     expect(mockIds).not.toHaveBeenCalled()
     expect(mockDeps).not.toHaveBeenCalled()

--- a/services/apps/packages_worker/src/packagist/__tests__/persistMetadata.test.ts
+++ b/services/apps/packages_worker/src/packagist/__tests__/persistMetadata.test.ts
@@ -214,9 +214,8 @@ describe('persistPackagistMetadata', () => {
   })
 
   it('returns the effective persisted homepage, not the raw candidate, when COALESCE retains the old value', async () => {
-    // updatePackagistVersionAggregates COALESCEs homepage — an omitted p2 field (null
-    // candidate) does NOT clear a previously-stored homepage. The caller reconciles the
-    // secondary repo link from this result, so it must reflect what's actually on the row.
+    // COALESCE keeps the stored homepage when p2 omits it; the result must reflect
+    // the row's actual value, not the null candidate.
     mockAggregates.mockResolvedValue({
       id: '9',
       changedFields: [],

--- a/services/apps/packages_worker/src/packagist/__tests__/persistPackageInfo.test.ts
+++ b/services/apps/packages_worker/src/packagist/__tests__/persistPackageInfo.test.ts
@@ -57,6 +57,7 @@ describe('persistPackagistPackageInfo', () => {
     mockUpdate.mockResolvedValue({
       id: '7',
       isCritical: true,
+      homepage: null,
       changedFields: ['packages.description'],
     })
     mockMaintainers.mockResolvedValue(['maintainers.display_name'])
@@ -78,7 +79,10 @@ describe('persistPackagistPackageInfo', () => {
     expect(mockUpdate.mock.calls[0][1]).not.toHaveProperty('downloadsLast30d')
     // canonicalized (lowercased) url + coarse host, linked with the manifest-declared convention
     expect(mockRepoGet).toHaveBeenCalledWith(qx, 'https://github.com/seldaek/monolog', 'github')
-    expect(mockRepoLink).toHaveBeenCalledWith(qx, '7', '55', { source: 'declared' })
+    expect(mockRepoLink).toHaveBeenCalledWith(qx, '7', '55', {
+      source: 'declared',
+      signal: 'primary',
+    })
     // any stale 'declared' link pointing at a different repo is pruned in the same pass
     expect(mockRepoRemove).toHaveBeenCalledWith(qx, '7', '55')
     expect(mockMaintainers).toHaveBeenCalledWith(qx, '7', stats.maintainers, 'packagist')
@@ -96,30 +100,36 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('skips maintainers for a non-critical package but still links the repo', async () => {
-    mockUpdate.mockResolvedValue({ id: '8', isCritical: false, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '8', isCritical: false, homepage: null, changedFields: [] })
 
     await persistPackagistPackageInfo(qx, PURL, stats)
 
     expect(mockMaintainers).not.toHaveBeenCalled()
     expect(mockRepoGet).toHaveBeenCalledWith(qx, 'https://github.com/seldaek/monolog', 'github')
-    expect(mockRepoLink).toHaveBeenCalledWith(qx, '8', '55', { source: 'declared' })
+    expect(mockRepoLink).toHaveBeenCalledWith(qx, '8', '55', {
+      source: 'declared',
+      signal: 'primary',
+    })
   })
 
   it('prunes a stale declared link when the repository URL switches to a different repo', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: false, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: false, homepage: null, changedFields: [] })
     mockRepoGet.mockResolvedValue({ id: '99', changedFields: [] })
     mockRepoRemove.mockResolvedValue(['package_repos.repo_id'])
 
     const result = await persistPackagistPackageInfo(qx, PURL, stats)
 
-    expect(mockRepoLink).toHaveBeenCalledWith(qx, '7', '99', { source: 'declared' })
+    expect(mockRepoLink).toHaveBeenCalledWith(qx, '7', '99', {
+      source: 'declared',
+      signal: 'primary',
+    })
     // old link (some other repo_id) removed, new one (99) kept
     expect(mockRepoRemove).toHaveBeenCalledWith(qx, '7', '99')
     expect(result.changedFields).toContain('package_repos.repo_id')
   })
 
   it('reconciles a maintainer list that dropped to empty for a critical package', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, homepage: null, changedFields: [] })
     mockMaintainers.mockResolvedValue(['package_maintainers.maintainer_id'])
 
     const result = await persistPackagistPackageInfo(qx, PURL, { ...stats, maintainers: [] })
@@ -131,7 +141,7 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('skips the repo link and clears any previously-declared one when there is no repository URL', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, homepage: null, changedFields: [] })
     mockRepoRemove.mockResolvedValue(['package_repos.repo_id'])
 
     const result = await persistPackagistPackageInfo(qx, PURL, { ...stats, repositoryUrl: null })
@@ -143,8 +153,40 @@ describe('persistPackagistPackageInfo', () => {
     expect(result.changedFields).toContain('package_repos.repo_id')
   })
 
+  it('falls back to the stored homepage with a secondary signal when no repository URL is declared', async () => {
+    mockUpdate.mockResolvedValue({
+      id: '7',
+      isCritical: true,
+      homepage: 'https://github.com/Seldaek/monolog',
+      changedFields: [],
+    })
+
+    await persistPackagistPackageInfo(qx, PURL, { ...stats, repositoryUrl: null })
+
+    expect(mockRepoGet).toHaveBeenCalledWith(qx, 'https://github.com/seldaek/monolog', 'github')
+    expect(mockRepoLink).toHaveBeenCalledWith(qx, '7', '55', {
+      source: 'declared',
+      signal: 'secondary',
+    })
+  })
+
+  it('rejects a homepage fallback that is not on a recognized VCS host', async () => {
+    mockUpdate.mockResolvedValue({
+      id: '7',
+      isCritical: true,
+      homepage: 'https://monolog.example.com/docs/intro',
+      changedFields: [],
+    })
+
+    await persistPackagistPackageInfo(qx, PURL, { ...stats, repositoryUrl: null })
+
+    expect(mockRepoGet).not.toHaveBeenCalled()
+    expect(mockRepoLink).not.toHaveBeenCalled()
+    expect(mockRepoRemove).toHaveBeenCalledWith(qx, '7')
+  })
+
   it('skips the repo link and clears the stale one when the repository URL cannot be canonicalized', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, homepage: null, changedFields: [] })
 
     await persistPackagistPackageInfo(qx, PURL, { ...stats, repositoryUrl: 'not-a-valid-url' })
 
@@ -154,7 +196,7 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('does not trust a canonicalized host outside the SCM allowlist (wiki/issue-tracker/registry URLs)', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, homepage: null, changedFields: [] })
 
     await persistPackagistPackageInfo(qx, PURL, {
       ...stats,
@@ -173,6 +215,7 @@ describe('persistPackagistPackageInfo', () => {
     mockUpdate.mockResolvedValue({
       id: '7',
       isCritical: false,
+      homepage: null,
       changedFields: ['packages.description'],
     })
     mockRepoGet.mockResolvedValue({ id: '55', changedFields: ['repos.url', 'repos.host'] })
@@ -202,7 +245,7 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('strips NUL bytes from the description before writing (Postgres rejects them)', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: false, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: false, homepage: null, changedFields: [] })
 
     await persistPackagistPackageInfo(qx, PURL, {
       ...stats,

--- a/services/apps/packages_worker/src/packagist/__tests__/persistPackageInfo.test.ts
+++ b/services/apps/packages_worker/src/packagist/__tests__/persistPackageInfo.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   getOrCreateRepoByUrl,
+  getPackageHomepage,
   logAuditFieldChanges,
   removeDeclaredPackageRepo,
-  setPackageRepositoryUrl,
   updatePackagistPackageStats,
   upsertPackageMaintainers,
   upsertPackageRepo,
@@ -20,7 +20,7 @@ vi.mock('@crowd/data-access-layer/src/packages', () => ({
   getOrCreateRepoByUrl: vi.fn(),
   upsertPackageRepo: vi.fn().mockResolvedValue([]),
   removeDeclaredPackageRepo: vi.fn().mockResolvedValue([]),
-  setPackageRepositoryUrl: vi.fn().mockResolvedValue([]),
+  getPackageHomepage: vi.fn().mockResolvedValue(null),
   logAuditFieldChanges: vi.fn(),
 }))
 
@@ -29,7 +29,7 @@ const mockMaintainers = vi.mocked(upsertPackageMaintainers)
 const mockRepoGet = vi.mocked(getOrCreateRepoByUrl)
 const mockRepoLink = vi.mocked(upsertPackageRepo)
 const mockRepoRemove = vi.mocked(removeDeclaredPackageRepo)
-const mockSetRepositoryUrl = vi.mocked(setPackageRepositoryUrl)
+const mockGetHomepage = vi.mocked(getPackageHomepage)
 const mockAudit = vi.mocked(logAuditFieldChanges)
 
 const qx = {
@@ -60,7 +60,6 @@ describe('persistPackagistPackageInfo', () => {
     mockUpdate.mockResolvedValue({
       id: '7',
       isCritical: true,
-      homepage: null,
       changedFields: ['packages.description'],
     })
     mockMaintainers.mockResolvedValue(['maintainers.display_name'])
@@ -103,7 +102,7 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('skips maintainers for a non-critical package but still links the repo', async () => {
-    mockUpdate.mockResolvedValue({ id: '8', isCritical: false, homepage: null, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '8', isCritical: false, changedFields: [] })
 
     await persistPackagistPackageInfo(qx, PURL, stats)
 
@@ -116,7 +115,7 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('prunes a stale declared link when the repository URL switches to a different repo', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: false, homepage: null, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: false, changedFields: [] })
     mockRepoGet.mockResolvedValue({ id: '99', changedFields: [] })
     mockRepoRemove.mockResolvedValue(['package_repos.repo_id'])
 
@@ -132,7 +131,7 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('reconciles a maintainer list that dropped to empty for a critical package', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, homepage: null, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, changedFields: [] })
     mockMaintainers.mockResolvedValue(['package_maintainers.maintainer_id'])
 
     const result = await persistPackagistPackageInfo(qx, PURL, { ...stats, maintainers: [] })
@@ -144,7 +143,7 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('skips the repo link and clears any previously-declared one when there is no repository URL', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, homepage: null, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, changedFields: [] })
     mockRepoRemove.mockResolvedValue(['package_repos.repo_id'])
 
     const result = await persistPackagistPackageInfo(qx, PURL, { ...stats, repositoryUrl: null })
@@ -157,10 +156,10 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('falls back to the stored homepage with a secondary signal when no repository URL is declared', async () => {
+    mockGetHomepage.mockResolvedValue('https://github.com/Seldaek/monolog')
     mockUpdate.mockResolvedValue({
       id: '7',
       isCritical: true,
-      homepage: 'https://github.com/Seldaek/monolog',
       changedFields: [],
     })
 
@@ -171,14 +170,17 @@ describe('persistPackagistPackageInfo', () => {
       source: 'declared',
       signal: 'secondary',
     })
-    expect(mockSetRepositoryUrl).toHaveBeenCalledWith(qx, '7', 'https://github.com/seldaek/monolog')
+    expect(mockUpdate).toHaveBeenCalledWith(
+      qx,
+      expect.objectContaining({ repositoryUrl: 'https://github.com/seldaek/monolog' }),
+    )
   })
 
   it('rejects a homepage fallback that is not on a recognized VCS host', async () => {
+    mockGetHomepage.mockResolvedValue('https://monolog.example.com/docs/intro')
     mockUpdate.mockResolvedValue({
       id: '7',
       isCritical: true,
-      homepage: 'https://monolog.example.com/docs/intro',
       changedFields: [],
     })
 
@@ -190,7 +192,7 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('skips the repo link and clears the stale one when the repository URL cannot be canonicalized', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, homepage: null, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, changedFields: [] })
 
     await persistPackagistPackageInfo(qx, PURL, { ...stats, repositoryUrl: 'not-a-valid-url' })
 
@@ -200,7 +202,7 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('does not trust a canonicalized host outside the SCM allowlist (wiki/issue-tracker/registry URLs)', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, homepage: null, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: true, changedFields: [] })
 
     await persistPackagistPackageInfo(qx, PURL, {
       ...stats,
@@ -219,7 +221,6 @@ describe('persistPackagistPackageInfo', () => {
     mockUpdate.mockResolvedValue({
       id: '7',
       isCritical: false,
-      homepage: null,
       changedFields: ['packages.description'],
     })
     mockRepoGet.mockResolvedValue({ id: '55', changedFields: ['repos.url', 'repos.host'] })
@@ -249,7 +250,7 @@ describe('persistPackagistPackageInfo', () => {
   })
 
   it('strips NUL bytes from the description before writing (Postgres rejects them)', async () => {
-    mockUpdate.mockResolvedValue({ id: '7', isCritical: false, homepage: null, changedFields: [] })
+    mockUpdate.mockResolvedValue({ id: '7', isCritical: false, changedFields: [] })
 
     await persistPackagistPackageInfo(qx, PURL, {
       ...stats,

--- a/services/apps/packages_worker/src/packagist/__tests__/persistPackageInfo.test.ts
+++ b/services/apps/packages_worker/src/packagist/__tests__/persistPackageInfo.test.ts
@@ -5,6 +5,7 @@ import {
   getPackageHomepage,
   logAuditFieldChanges,
   removeDeclaredPackageRepo,
+  setPackageRepositoryUrl,
   updatePackagistPackageStats,
   upsertPackageMaintainers,
   upsertPackageRepo,
@@ -12,7 +13,7 @@ import {
 import type { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
 import type { NormalizedPackagistStats } from '../types'
-import { persistPackagistPackageInfo } from '../upsertPackageInfo'
+import { persistPackagistPackageInfo, reconcilePackagistHomepageRepo } from '../upsertPackageInfo'
 
 vi.mock('@crowd/data-access-layer/src/packages', () => ({
   updatePackagistPackageStats: vi.fn(),
@@ -21,6 +22,7 @@ vi.mock('@crowd/data-access-layer/src/packages', () => ({
   upsertPackageRepo: vi.fn().mockResolvedValue([]),
   removeDeclaredPackageRepo: vi.fn().mockResolvedValue([]),
   getPackageHomepage: vi.fn().mockResolvedValue(null),
+  setPackageRepositoryUrl: vi.fn().mockResolvedValue([]),
   logAuditFieldChanges: vi.fn(),
 }))
 
@@ -30,6 +32,7 @@ const mockRepoGet = vi.mocked(getOrCreateRepoByUrl)
 const mockRepoLink = vi.mocked(upsertPackageRepo)
 const mockRepoRemove = vi.mocked(removeDeclaredPackageRepo)
 const mockGetHomepage = vi.mocked(getPackageHomepage)
+const mockSetRepositoryUrl = vi.mocked(setPackageRepositoryUrl)
 const mockAudit = vi.mocked(logAuditFieldChanges)
 
 const qx = {
@@ -243,7 +246,12 @@ describe('persistPackagistPackageInfo', () => {
 
     const result = await persistPackagistPackageInfo(qx, PURL, stats)
 
-    expect(result).toEqual({ found: false, changedFields: [] })
+    expect(result).toEqual({
+      found: false,
+      changedFields: [],
+      packageId: null,
+      hasPrimaryRepo: true,
+    })
     expect(mockRepoGet).not.toHaveBeenCalled()
     expect(mockMaintainers).not.toHaveBeenCalled()
     expect(mockAudit).not.toHaveBeenCalled()
@@ -261,5 +269,54 @@ describe('persistPackagistPackageInfo', () => {
       qx,
       expect.objectContaining({ description: 'Esta es una descripcin random' }),
     )
+  })
+})
+
+// Phase 1 links a homepage-fallback repo from whatever homepage is already stored;
+// this reconciles it once phase 2 has persisted a fresh homepage for a package that
+// had none yet (a new package, or one whose homepage just changed).
+describe('reconcilePackagistHomepageRepo', () => {
+  beforeEach(() => {
+    mockRepoGet.mockResolvedValue({ id: '55', changedFields: [] })
+  })
+
+  it('links the fresh homepage with a secondary signal', async () => {
+    mockSetRepositoryUrl.mockResolvedValue(['packages.repository_url'])
+    mockRepoLink.mockResolvedValue(['package_repos.repo_id'])
+
+    const changedFields = await reconcilePackagistHomepageRepo(
+      qx,
+      PURL,
+      '7',
+      'https://github.com/Seldaek/monolog',
+    )
+
+    expect(mockSetRepositoryUrl).toHaveBeenCalledWith(qx, '7', 'https://github.com/seldaek/monolog')
+    expect(mockRepoGet).toHaveBeenCalledWith(qx, 'https://github.com/seldaek/monolog', 'github')
+    expect(mockRepoLink).toHaveBeenCalledWith(qx, '7', '55', {
+      source: 'declared',
+      signal: 'secondary',
+    })
+    expect(mockRepoRemove).toHaveBeenCalledWith(qx, '7', '55')
+    expect(changedFields).toContain('packages.repository_url')
+  })
+
+  it('clears the link when there is no homepage to fall back to', async () => {
+    mockRepoRemove.mockResolvedValue(['package_repos.repo_id'])
+
+    await reconcilePackagistHomepageRepo(qx, PURL, '7', null)
+
+    expect(mockSetRepositoryUrl).toHaveBeenCalledWith(qx, '7', null)
+    expect(mockRepoGet).not.toHaveBeenCalled()
+    expect(mockRepoLink).not.toHaveBeenCalled()
+    expect(mockRepoRemove).toHaveBeenCalledWith(qx, '7')
+  })
+
+  it('clears the link when the homepage is not on a recognized VCS host', async () => {
+    await reconcilePackagistHomepageRepo(qx, PURL, '7', 'https://monolog.example.com/docs')
+
+    expect(mockSetRepositoryUrl).toHaveBeenCalledWith(qx, '7', null)
+    expect(mockRepoGet).not.toHaveBeenCalled()
+    expect(mockRepoLink).not.toHaveBeenCalled()
   })
 })

--- a/services/apps/packages_worker/src/packagist/__tests__/persistPackageInfo.test.ts
+++ b/services/apps/packages_worker/src/packagist/__tests__/persistPackageInfo.test.ts
@@ -4,6 +4,7 @@ import {
   getOrCreateRepoByUrl,
   logAuditFieldChanges,
   removeDeclaredPackageRepo,
+  setPackageRepositoryUrl,
   updatePackagistPackageStats,
   upsertPackageMaintainers,
   upsertPackageRepo,
@@ -19,6 +20,7 @@ vi.mock('@crowd/data-access-layer/src/packages', () => ({
   getOrCreateRepoByUrl: vi.fn(),
   upsertPackageRepo: vi.fn().mockResolvedValue([]),
   removeDeclaredPackageRepo: vi.fn().mockResolvedValue([]),
+  setPackageRepositoryUrl: vi.fn().mockResolvedValue([]),
   logAuditFieldChanges: vi.fn(),
 }))
 
@@ -27,6 +29,7 @@ const mockMaintainers = vi.mocked(upsertPackageMaintainers)
 const mockRepoGet = vi.mocked(getOrCreateRepoByUrl)
 const mockRepoLink = vi.mocked(upsertPackageRepo)
 const mockRepoRemove = vi.mocked(removeDeclaredPackageRepo)
+const mockSetRepositoryUrl = vi.mocked(setPackageRepositoryUrl)
 const mockAudit = vi.mocked(logAuditFieldChanges)
 
 const qx = {
@@ -168,6 +171,7 @@ describe('persistPackagistPackageInfo', () => {
       source: 'declared',
       signal: 'secondary',
     })
+    expect(mockSetRepositoryUrl).toHaveBeenCalledWith(qx, '7', 'https://github.com/seldaek/monolog')
   })
 
   it('rejects a homepage fallback that is not on a recognized VCS host', async () => {

--- a/services/apps/packages_worker/src/packagist/__tests__/persistPackageInfo.test.ts
+++ b/services/apps/packages_worker/src/packagist/__tests__/persistPackageInfo.test.ts
@@ -272,9 +272,8 @@ describe('persistPackagistPackageInfo', () => {
   })
 })
 
-// Phase 1 links a homepage-fallback repo from whatever homepage is already stored;
-// this reconciles it once phase 2 has persisted a fresh homepage for a package that
-// had none yet (a new package, or one whose homepage just changed).
+// Reconciles the homepage-fallback repo link after phase 2 persists a fresh
+// homepage, since phase 1 only linked from whatever was stored before it.
 describe('reconcilePackagistHomepageRepo', () => {
   beforeEach(() => {
     mockRepoGet.mockResolvedValue({ id: '55', changedFields: [] })

--- a/services/apps/packages_worker/src/packagist/activities.ts
+++ b/services/apps/packages_worker/src/packagist/activities.ts
@@ -49,7 +49,7 @@ import { normalizePackagistStats, packagistNameFromPurl } from './normalize'
 import { INGEST_MAX_ATTEMPTS, TRANSITIVE_PREPARE_MAX_ATTEMPTS } from './retryPolicy'
 import { FetchError, isFetchError, isP2NotModified } from './types'
 import { persistPackagistMetadata } from './upsertMetadata'
-import { persistPackagistPackageInfo } from './upsertPackageInfo'
+import { persistPackagistPackageInfo, reconcilePackagistHomepageRepo } from './upsertPackageInfo'
 
 const log = getServiceChildLogger('packagist')
 
@@ -175,7 +175,7 @@ export async function ingestOnePackagistMetadata(
   // persistPackagistPackageInfo audits its own writes atomically, inside the same
   // transaction — phase 1 is committed-and-audited before the p2 fetch (which can
   // throw) ever runs.
-  await persistPackagistPackageInfo(qx, candidate.purl, stats)
+  const phase1 = await persistPackagistPackageInfo(qx, candidate.purl, stats)
 
   // Phase 2: p2 endpoint
   const p2 = await fetchWithFastRetry(
@@ -207,6 +207,17 @@ export async function ingestOnePackagistMetadata(
       log.debug(
         { purl: candidate.purl, unresolved: persistResult.unresolvedDependencyTargets },
         'packagist dependency targets not found in packages — edges skipped',
+      )
+    }
+    // Phase 1's homepage-fallback repo link used whatever homepage was already stored —
+    // for a new package, or one whose homepage just changed, that's stale/absent until
+    // this p2 write lands it. Reconcile now so the link doesn't wait for the next run.
+    if (!phase1.hasPrimaryRepo && phase1.packageId) {
+      await reconcilePackagistHomepageRepo(
+        qx,
+        candidate.purl,
+        phase1.packageId,
+        persistResult.homepage,
       )
     }
     lastModified = p2.value.lastModified

--- a/services/apps/packages_worker/src/packagist/activities.ts
+++ b/services/apps/packages_worker/src/packagist/activities.ts
@@ -209,9 +209,8 @@ export async function ingestOnePackagistMetadata(
         'packagist dependency targets not found in packages — edges skipped',
       )
     }
-    // Phase 1's homepage-fallback repo link used whatever homepage was already stored —
-    // for a new package, or one whose homepage just changed, that's stale/absent until
-    // this p2 write lands it. Reconcile now so the link doesn't wait for the next run.
+    // Must run after persistPackagistMetadata above — it just landed the homepage this
+    // fallback link depends on.
     if (!phase1.hasPrimaryRepo && phase1.packageId) {
       await reconcilePackagistHomepageRepo(
         qx,

--- a/services/apps/packages_worker/src/packagist/upsertMetadata.ts
+++ b/services/apps/packages_worker/src/packagist/upsertMetadata.ts
@@ -23,7 +23,12 @@ export async function persistPackagistMetadata(
   qx: QueryExecutor,
   purl: string,
   expanded: PackagistExpandedVersion[],
-): Promise<{ found: boolean; changedFields: string[]; unresolvedDependencyTargets: number }> {
+): Promise<{
+  found: boolean
+  changedFields: string[]
+  unresolvedDependencyTargets: number
+  homepage: string | null
+}> {
   // Registry data can contain NUL bytes (e.g. mojibake descriptions/licenses) that
   // Postgres text columns reject; strip them before any field is persisted.
   stripNullBytesDeep(expanded)
@@ -114,5 +119,5 @@ export async function persistPackagistMetadata(
     await logAuditFieldChanges(t, WORKER, purl, changedFields)
   })
 
-  return { found, changedFields, unresolvedDependencyTargets }
+  return { found, changedFields, unresolvedDependencyTargets, homepage }
 }

--- a/services/apps/packages_worker/src/packagist/upsertMetadata.ts
+++ b/services/apps/packages_worker/src/packagist/upsertMetadata.ts
@@ -37,6 +37,7 @@ export async function persistPackagistMetadata(
     buildPackagistVersionRows(expanded)
 
   let found = false
+  let effectiveHomepage: string | null = null
   const changedFields: string[] = []
   let unresolvedDependencyTargets = 0
 
@@ -58,6 +59,7 @@ export async function persistPackagistMetadata(
     if (!agg) return
 
     found = true
+    effectiveHomepage = agg.homepage
     changedFields.push(...agg.changedFields)
 
     let versionIds: Array<{ number: string; id: string }> = []
@@ -119,5 +121,5 @@ export async function persistPackagistMetadata(
     await logAuditFieldChanges(t, WORKER, purl, changedFields)
   })
 
-  return { found, changedFields, unresolvedDependencyTargets, homepage }
+  return { found, changedFields, unresolvedDependencyTargets, homepage: effectiveHomepage }
 }

--- a/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
+++ b/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
@@ -9,6 +9,7 @@ import {
 import type { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
 import { canonicalizeRepoUrl } from '../utils/canonicalizeRepoUrl'
+import { resolveManifestRepo } from '../utils/resolveManifestRepo'
 import { stripNullBytesDeep } from '../utils/stripNullBytesDeep'
 
 import type { NormalizedPackagistStats } from './types'
@@ -31,13 +32,13 @@ export async function persistPackagistPackageInfo(
   // text columns reject; strip them before any field is persisted.
   stripNullBytesDeep(stats)
 
-  const canonical = stats.repositoryUrl ? canonicalizeRepoUrl(stats.repositoryUrl) : null
   // Packagist's repository field is free-form/author-supplied. canonicalizeRepoUrl's
   // 'other' bucket also matches non-repo URLs (wikis, issue trackers, registry pages)
   // that happen to have 2+ path segments, so only trust the verified SCM hosts here —
   // github.com/gitlab.com/bitbucket.org — rather than the shared utility's default,
   // which other callers (npm/maven/cargo) rely on staying permissive.
-  const trustedRepo = canonical && canonical.host !== 'other' ? canonical : null
+  const declared = stats.repositoryUrl ? canonicalizeRepoUrl(stats.repositoryUrl) : null
+  const primaryRepo = declared && declared.host !== 'other' ? declared : null
 
   let found = false
   const changedFields: string[] = []
@@ -48,7 +49,7 @@ export async function persistPackagistPackageInfo(
       purl,
       description: stats.description,
       declaredRepositoryUrl: stats.repositoryUrl,
-      repositoryUrl: trustedRepo?.url ?? null,
+      repositoryUrl: primaryRepo?.url ?? null,
       status: stats.status,
       totalDownloads: stats.downloadsTotal,
       dependentCount: stats.dependents,
@@ -60,14 +61,23 @@ export async function persistPackagistPackageInfo(
     const { id, isCritical } = result
     changedFields.push(...result.changedFields)
 
+    // The version manifests carry the homepage, not this endpoint — read back the one the
+    // metadata lane stored so a package that only declares a homepage still gets a link.
+    const resolvedRepo = primaryRepo
+      ? { repo: primaryRepo, signal: 'primary' as const }
+      : resolveManifestRepo([{ field: 'homepage', url: result.homepage, signal: 'secondary' }])
+
     // When there's no trusted repo (removed from the manifest, or no longer
     // canonicalizable to a known host), or it now resolves to a different repo, clear any
     // previously-declared link that no longer applies — package_repos' unique key is
     // (package_id, repo_id), not (package_id, source), so upserting the new link alone
     // would leave a stale one dangling.
-    if (trustedRepo) {
-      const repo = await getOrCreateRepoByUrl(t, trustedRepo.url, trustedRepo.host)
-      const linkChanged = await upsertPackageRepo(t, id, repo.id, { source: 'declared' })
+    if (resolvedRepo) {
+      const repo = await getOrCreateRepoByUrl(t, resolvedRepo.repo.url, resolvedRepo.repo.host)
+      const linkChanged = await upsertPackageRepo(t, id, repo.id, {
+        source: 'declared',
+        signal: resolvedRepo.signal,
+      })
       const removedFields = await removeDeclaredPackageRepo(t, id, repo.id)
       changedFields.push(...repo.changedFields, ...linkChanged, ...removedFields)
     } else {

--- a/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
+++ b/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
@@ -80,6 +80,15 @@ export async function persistPackagistPackageInfo(
       })
       const removedFields = await removeDeclaredPackageRepo(t, id, repo.id)
       changedFields.push(...repo.changedFields, ...linkChanged, ...removedFields)
+
+      if (resolvedRepo.signal === 'secondary') {
+        const repoUrlChanged = await t.result(
+          `UPDATE packages SET repository_url = $(url) WHERE id = $(id)::bigint
+             AND (repository_url IS DISTINCT FROM $(url))`,
+          { url: resolvedRepo.repo.url, id },
+        )
+        if (repoUrlChanged > 0) changedFields.push('packages.repository_url')
+      }
     } else {
       const removedFields = await removeDeclaredPackageRepo(t, id)
       changedFields.push(...removedFields)

--- a/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
+++ b/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
@@ -2,6 +2,7 @@ import {
   getOrCreateRepoByUrl,
   logAuditFieldChanges,
   removeDeclaredPackageRepo,
+  setPackageRepositoryUrl,
   updatePackagistPackageStats,
   upsertPackageMaintainers,
   upsertPackageRepo,
@@ -82,12 +83,7 @@ export async function persistPackagistPackageInfo(
       changedFields.push(...repo.changedFields, ...linkChanged, ...removedFields)
 
       if (resolvedRepo.signal === 'secondary') {
-        const repoUrlChanged = await t.result(
-          `UPDATE packages SET repository_url = $(url) WHERE id = $(id)::bigint
-             AND (repository_url IS DISTINCT FROM $(url))`,
-          { url: resolvedRepo.repo.url, id },
-        )
-        if (repoUrlChanged > 0) changedFields.push('packages.repository_url')
+        changedFields.push(...(await setPackageRepositoryUrl(t, id, resolvedRepo.repo.url)))
       }
     } else {
       const removedFields = await removeDeclaredPackageRepo(t, id)

--- a/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
+++ b/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
@@ -54,10 +54,12 @@ export async function persistPackagistPackageInfo(
   await qx.tx(async (t) => {
     // The version manifests carry the homepage, not this endpoint — peek at the stored
     // homepage so a homepage-only package still gets linked without a second write later.
-    const storedHomepage = await getPackageHomepage(t, purl)
+    // Only needed when there's no primary repo to fall back from.
     const resolvedRepo = primaryRepo
       ? { repo: primaryRepo, signal: 'primary' as const }
-      : resolveManifestRepo([{ field: 'homepage', url: storedHomepage, signal: 'secondary' }])
+      : resolveManifestRepo([
+          { field: 'homepage', url: await getPackageHomepage(t, purl), signal: 'secondary' },
+        ])
 
     // Step 1: Update packages row
     const result = await updatePackagistPackageStats(t, {

--- a/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
+++ b/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
@@ -3,6 +3,7 @@ import {
   getPackageHomepage,
   logAuditFieldChanges,
   removeDeclaredPackageRepo,
+  setPackageRepositoryUrl,
   updatePackagistPackageStats,
   upsertPackageMaintainers,
   upsertPackageRepo,
@@ -28,7 +29,12 @@ export async function persistPackagistPackageInfo(
   qx: QueryExecutor,
   purl: string,
   stats: NormalizedPackagistStats,
-): Promise<{ found: boolean; changedFields: string[] }> {
+): Promise<{
+  found: boolean
+  changedFields: string[]
+  packageId: string | null
+  hasPrimaryRepo: boolean
+}> {
   // Registry data can contain NUL bytes (e.g. mojibake descriptions) that Postgres
   // text columns reject; strip them before any field is persisted.
   stripNullBytesDeep(stats)
@@ -42,6 +48,7 @@ export async function persistPackagistPackageInfo(
   const primaryRepo = declared && declared.host !== 'other' ? declared : null
 
   let found = false
+  let packageId: string | null = null
   const changedFields: string[] = []
 
   await qx.tx(async (t) => {
@@ -68,6 +75,7 @@ export async function persistPackagistPackageInfo(
 
     found = true
     const { id, isCritical } = result
+    packageId = id
     changedFields.push(...result.changedFields)
 
     // When there's no trusted repo (removed from the manifest, or no longer
@@ -105,5 +113,39 @@ export async function persistPackagistPackageInfo(
     await logAuditFieldChanges(t, WORKER, purl, changedFields)
   })
 
-  return { found, changedFields }
+  return { found, changedFields, packageId, hasPrimaryRepo: !!primaryRepo }
+}
+
+// Phase 1 (dynamic endpoint) resolves the homepage-fallback repo from whatever homepage
+// is already stored, but the p2 endpoint (phase 2) is what actually carries a new/changed
+// homepage — see ingestOnePackagistMetadata. Called after phase 2 persists, so a package
+// with no declared repository field still gets linked to its homepage in the same run it's
+// first seen, instead of waiting for the next scheduled ingestion.
+export async function reconcilePackagistHomepageRepo(
+  qx: QueryExecutor,
+  purl: string,
+  packageId: string,
+  homepage: string | null,
+): Promise<string[]> {
+  const resolved = resolveManifestRepo([{ field: 'homepage', url: homepage, signal: 'secondary' }])
+  const changedFields: string[] = []
+
+  await qx.tx(async (t) => {
+    changedFields.push(...(await setPackageRepositoryUrl(t, packageId, resolved?.repo.url ?? null)))
+    if (resolved) {
+      const repo = await getOrCreateRepoByUrl(t, resolved.repo.url, resolved.repo.host)
+      const linkChanged = await upsertPackageRepo(t, packageId, repo.id, {
+        source: 'declared',
+        signal: 'secondary',
+      })
+      const removedFields = await removeDeclaredPackageRepo(t, packageId, repo.id)
+      changedFields.push(...repo.changedFields, ...linkChanged, ...removedFields)
+    } else {
+      const removedFields = await removeDeclaredPackageRepo(t, packageId)
+      changedFields.push(...removedFields)
+    }
+    await logAuditFieldChanges(t, WORKER, purl, changedFields)
+  })
+
+  return changedFields
 }

--- a/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
+++ b/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
@@ -52,9 +52,8 @@ export async function persistPackagistPackageInfo(
   const changedFields: string[] = []
 
   await qx.tx(async (t) => {
-    // The version manifests carry the homepage, not this endpoint — peek at the stored
-    // homepage so a homepage-only package still gets linked without a second write later.
-    // Only needed when there's no primary repo to fall back from.
+    // This endpoint carries no homepage — only needed as a fallback, peek at the one
+    // already stored by the version-manifest write path.
     const resolvedRepo = primaryRepo
       ? { repo: primaryRepo, signal: 'primary' as const }
       : resolveManifestRepo([

--- a/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
+++ b/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
@@ -1,8 +1,8 @@
 import {
   getOrCreateRepoByUrl,
+  getPackageHomepage,
   logAuditFieldChanges,
   removeDeclaredPackageRepo,
-  setPackageRepositoryUrl,
   updatePackagistPackageStats,
   upsertPackageMaintainers,
   upsertPackageRepo,
@@ -45,12 +45,20 @@ export async function persistPackagistPackageInfo(
   const changedFields: string[] = []
 
   await qx.tx(async (t) => {
+    // The version manifests carry the homepage, not this endpoint — peek at the currently
+    // stored homepage so a package that only declares a homepage still gets a link, without
+    // a second write once the stats row is updated below.
+    const storedHomepage = await getPackageHomepage(t, purl)
+    const resolvedRepo = primaryRepo
+      ? { repo: primaryRepo, signal: 'primary' as const }
+      : resolveManifestRepo([{ field: 'homepage', url: storedHomepage, signal: 'secondary' }])
+
     // Step 1: Update packages row
     const result = await updatePackagistPackageStats(t, {
       purl,
       description: stats.description,
       declaredRepositoryUrl: stats.repositoryUrl,
-      repositoryUrl: primaryRepo?.url ?? null,
+      repositoryUrl: resolvedRepo?.repo.url ?? null,
       status: stats.status,
       totalDownloads: stats.downloadsTotal,
       dependentCount: stats.dependents,
@@ -61,12 +69,6 @@ export async function persistPackagistPackageInfo(
     found = true
     const { id, isCritical } = result
     changedFields.push(...result.changedFields)
-
-    // The version manifests carry the homepage, not this endpoint — read back the one the
-    // metadata lane stored so a package that only declares a homepage still gets a link.
-    const resolvedRepo = primaryRepo
-      ? { repo: primaryRepo, signal: 'primary' as const }
-      : resolveManifestRepo([{ field: 'homepage', url: result.homepage, signal: 'secondary' }])
 
     // When there's no trusted repo (removed from the manifest, or no longer
     // canonicalizable to a known host), or it now resolves to a different repo, clear any
@@ -81,10 +83,6 @@ export async function persistPackagistPackageInfo(
       })
       const removedFields = await removeDeclaredPackageRepo(t, id, repo.id)
       changedFields.push(...repo.changedFields, ...linkChanged, ...removedFields)
-
-      if (resolvedRepo.signal === 'secondary') {
-        changedFields.push(...(await setPackageRepositoryUrl(t, id, resolvedRepo.repo.url)))
-      }
     } else {
       const removedFields = await removeDeclaredPackageRepo(t, id)
       changedFields.push(...removedFields)

--- a/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
+++ b/services/apps/packages_worker/src/packagist/upsertPackageInfo.ts
@@ -52,9 +52,8 @@ export async function persistPackagistPackageInfo(
   const changedFields: string[] = []
 
   await qx.tx(async (t) => {
-    // The version manifests carry the homepage, not this endpoint — peek at the currently
-    // stored homepage so a package that only declares a homepage still gets a link, without
-    // a second write once the stats row is updated below.
+    // The version manifests carry the homepage, not this endpoint — peek at the stored
+    // homepage so a homepage-only package still gets linked without a second write later.
     const storedHomepage = await getPackageHomepage(t, purl)
     const resolvedRepo = primaryRepo
       ? { repo: primaryRepo, signal: 'primary' as const }
@@ -116,11 +115,8 @@ export async function persistPackagistPackageInfo(
   return { found, changedFields, packageId, hasPrimaryRepo: !!primaryRepo }
 }
 
-// Phase 1 (dynamic endpoint) resolves the homepage-fallback repo from whatever homepage
-// is already stored, but the p2 endpoint (phase 2) is what actually carries a new/changed
-// homepage — see ingestOnePackagistMetadata. Called after phase 2 persists, so a package
-// with no declared repository field still gets linked to its homepage in the same run it's
-// first seen, instead of waiting for the next scheduled ingestion.
+// Phase 1 resolves the homepage-fallback repo from whatever's already stored; phase 2
+// (called after it persists — see ingestOnePackagistMetadata) carries the actual new homepage.
 export async function reconcilePackagistHomepageRepo(
   qx: QueryExecutor,
   purl: string,

--- a/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
@@ -247,6 +247,7 @@ describe('classifyProjectUrls', () => {
     )
     expect(r.homepage).toBe('https://flask.palletsprojects.com/')
     expect(r.declaredRepositoryUrl).toBe('https://github.com/pallets/flask/')
+    expect(r.declaredRepositoryField).toBe('source')
     expect(r.fundingLinks).toEqual([{ type: 'other', url: 'https://palletsprojects.com/donate' }])
   })
 
@@ -258,6 +259,28 @@ describe('classifyProjectUrls', () => {
   it('falls back to a repo-looking homepage when no explicit repo key', () => {
     const r = classifyProjectUrls({ Homepage: 'https://github.com/psf/requests' }, null)
     expect(r.declaredRepositoryUrl).toBe('https://github.com/psf/requests')
+    expect(r.declaredRepositoryField).toBe('homepage')
+  })
+
+  it('falls back to bug tracker URL when no explicit repo or homepage repo', () => {
+    const r = classifyProjectUrls(
+      { 'Bug Tracker': 'https://github.com/foo/bar/issues' },
+      null,
+    )
+    expect(r.declaredRepositoryUrl).toBe('https://github.com/foo/bar/issues')
+    expect(r.declaredRepositoryField).toBe('bug_tracker')
+  })
+
+  it('does not use bug tracker when an explicit repo key is present', () => {
+    const r = classifyProjectUrls(
+      {
+        Source: 'https://github.com/foo/bar',
+        'Bug Tracker': 'https://github.com/foo/bar/issues',
+      },
+      null,
+    )
+    expect(r.declaredRepositoryUrl).toBe('https://github.com/foo/bar')
+    expect(r.declaredRepositoryField).toBe('source')
   })
 
   it('infers funding type from the host', () => {

--- a/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
@@ -271,6 +271,14 @@ describe('classifyProjectUrls', () => {
     expect(r.declaredRepositoryField).toBe('bug_tracker')
   })
 
+  it('does not classify GitHub Issues URL as source via the git heuristic', () => {
+    const r = classifyProjectUrls(
+      { 'GitHub Issues': 'https://github.com/foo/bar/issues' },
+      null,
+    )
+    expect(r.declaredRepositoryField).toBe('bug_tracker')
+  })
+
   it('does not use bug tracker when an explicit repo key is present', () => {
     const r = classifyProjectUrls(
       {

--- a/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
@@ -276,7 +276,12 @@ describe('classifyProjectUrls', () => {
 
   it('returns nulls/empties when there are no urls', () => {
     const r = classifyProjectUrls(null, null)
-    expect(r).toEqual({ homepage: null, declaredRepositoryUrl: null, fundingLinks: [] })
+    expect(r).toEqual({
+      homepage: null,
+      declaredRepositoryUrl: null,
+      declaredRepositoryField: null,
+      fundingLinks: [],
+    })
   })
 })
 

--- a/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
@@ -263,19 +263,13 @@ describe('classifyProjectUrls', () => {
   })
 
   it('falls back to bug tracker URL when no explicit repo or homepage repo', () => {
-    const r = classifyProjectUrls(
-      { 'Bug Tracker': 'https://github.com/foo/bar/issues' },
-      null,
-    )
+    const r = classifyProjectUrls({ 'Bug Tracker': 'https://github.com/foo/bar/issues' }, null)
     expect(r.declaredRepositoryUrl).toBe('https://github.com/foo/bar/issues')
     expect(r.declaredRepositoryField).toBe('bug_tracker')
   })
 
   it('does not classify GitHub Issues URL as source via the git heuristic', () => {
-    const r = classifyProjectUrls(
-      { 'GitHub Issues': 'https://github.com/foo/bar/issues' },
-      null,
-    )
+    const r = classifyProjectUrls({ 'GitHub Issues': 'https://github.com/foo/bar/issues' }, null)
     expect(r.declaredRepositoryField).toBe('bug_tracker')
   })
 

--- a/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
@@ -246,8 +246,9 @@ describe('classifyProjectUrls', () => {
       null,
     )
     expect(r.homepage).toBe('https://flask.palletsprojects.com/')
-    expect(r.declaredRepositoryUrl).toBe('https://github.com/pallets/flask/')
-    expect(r.declaredRepositoryField).toBe('source')
+    expect(r.repositoryCandidates).toEqual([
+      { field: 'source', url: 'https://github.com/pallets/flask/' },
+    ])
     expect(r.fundingLinks).toEqual([{ type: 'other', url: 'https://palletsprojects.com/donate' }])
   })
 
@@ -258,19 +259,23 @@ describe('classifyProjectUrls', () => {
 
   it('falls back to a repo-looking homepage when no explicit repo key', () => {
     const r = classifyProjectUrls({ Homepage: 'https://github.com/psf/requests' }, null)
-    expect(r.declaredRepositoryUrl).toBe('https://github.com/psf/requests')
-    expect(r.declaredRepositoryField).toBe('homepage')
+    expect(r.repositoryCandidates).toEqual([
+      { field: 'homepage', url: 'https://github.com/psf/requests' },
+    ])
   })
 
   it('falls back to bug tracker URL when no explicit repo or homepage repo', () => {
     const r = classifyProjectUrls({ 'Bug Tracker': 'https://github.com/foo/bar/issues' }, null)
-    expect(r.declaredRepositoryUrl).toBe('https://github.com/foo/bar/issues')
-    expect(r.declaredRepositoryField).toBe('bug_tracker')
+    expect(r.repositoryCandidates).toEqual([
+      { field: 'bug_tracker', url: 'https://github.com/foo/bar/issues' },
+    ])
   })
 
   it('does not classify GitHub Issues URL as source via the git heuristic', () => {
     const r = classifyProjectUrls({ 'GitHub Issues': 'https://github.com/foo/bar/issues' }, null)
-    expect(r.declaredRepositoryField).toBe('bug_tracker')
+    expect(r.repositoryCandidates).toEqual([
+      { field: 'bug_tracker', url: 'https://github.com/foo/bar/issues' },
+    ])
   })
 
   it('does not use bug tracker when an explicit repo key is present', () => {
@@ -281,8 +286,21 @@ describe('classifyProjectUrls', () => {
       },
       null,
     )
-    expect(r.declaredRepositoryUrl).toBe('https://github.com/foo/bar')
-    expect(r.declaredRepositoryField).toBe('source')
+    expect(r.repositoryCandidates).toEqual([{ field: 'source', url: 'https://github.com/foo/bar' }])
+  })
+
+  it('keeps the source candidate and a repo-looking homepage as a fallback', () => {
+    const r = classifyProjectUrls(
+      {
+        Source: 'https://github.com/foo/bar',
+        Homepage: 'https://gitlab.com/foo/bar',
+      },
+      null,
+    )
+    expect(r.repositoryCandidates).toEqual([
+      { field: 'source', url: 'https://github.com/foo/bar' },
+      { field: 'homepage', url: 'https://gitlab.com/foo/bar' },
+    ])
   })
 
   it('infers funding type from the host', () => {
@@ -303,8 +321,7 @@ describe('classifyProjectUrls', () => {
     const r = classifyProjectUrls(null, null)
     expect(r).toEqual({
       homepage: null,
-      declaredRepositoryUrl: null,
-      declaredRepositoryField: null,
+      repositoryCandidates: [],
       fundingLinks: [],
     })
   })

--- a/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
@@ -278,7 +278,7 @@ describe('classifyProjectUrls', () => {
     ])
   })
 
-  it('does not use bug tracker when an explicit repo key is present', () => {
+  it('keeps the bug tracker as a lower-priority fallback even when an explicit repo key is present', () => {
     const r = classifyProjectUrls(
       {
         Source: 'https://github.com/foo/bar',
@@ -286,7 +286,24 @@ describe('classifyProjectUrls', () => {
       },
       null,
     )
-    expect(r.repositoryCandidates).toEqual([{ field: 'source', url: 'https://github.com/foo/bar' }])
+    expect(r.repositoryCandidates).toEqual([
+      { field: 'source', url: 'https://github.com/foo/bar' },
+      { field: 'bug_tracker', url: 'https://github.com/foo/bar/issues' },
+    ])
+  })
+
+  it('keeps the bug tracker as a fallback when the source URL is present but malformed', () => {
+    const r = classifyProjectUrls(
+      {
+        Source: 'not-a-url',
+        'Bug Tracker': 'https://github.com/foo/bar/issues',
+      },
+      null,
+    )
+    expect(r.repositoryCandidates).toEqual([
+      { field: 'source', url: 'not-a-url' },
+      { field: 'bug_tracker', url: 'https://github.com/foo/bar/issues' },
+    ])
   })
 
   it('keeps the source candidate and a repo-looking homepage as a fallback', () => {

--- a/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
@@ -264,6 +264,23 @@ describe('classifyProjectUrls', () => {
     ])
   })
 
+  it('falls back to a repo-looking info.home_page when project_urls has no matching Homepage', () => {
+    const r = classifyProjectUrls({}, 'https://github.com/psf/requests')
+    expect(r.repositoryCandidates).toEqual([
+      { field: 'homepage', url: 'https://github.com/psf/requests' },
+    ])
+  })
+
+  it('prefers a repo-looking project_urls.Homepage over a non-repo info.home_page', () => {
+    const r = classifyProjectUrls(
+      { Homepage: 'https://github.com/psf/requests' },
+      'https://primary.example',
+    )
+    expect(r.repositoryCandidates).toEqual([
+      { field: 'homepage', url: 'https://github.com/psf/requests' },
+    ])
+  })
+
   it('falls back to bug tracker URL when no explicit repo or homepage repo', () => {
     const r = classifyProjectUrls({ 'Bug Tracker': 'https://github.com/foo/bar/issues' }, null)
     expect(r.repositoryCandidates).toEqual([

--- a/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/pypi/__tests__/normalize.test.ts
@@ -248,6 +248,7 @@ describe('classifyProjectUrls', () => {
     expect(r.homepage).toBe('https://flask.palletsprojects.com/')
     expect(r.repositoryCandidates).toEqual([
       { field: 'source', url: 'https://github.com/pallets/flask/' },
+      { field: 'homepage', url: 'https://flask.palletsprojects.com/' },
     ])
     expect(r.fundingLinks).toEqual([{ type: 'other', url: 'https://palletsprojects.com/donate' }])
   })
@@ -271,13 +272,14 @@ describe('classifyProjectUrls', () => {
     ])
   })
 
-  it('prefers a repo-looking project_urls.Homepage over a non-repo info.home_page', () => {
+  it('orders a repo-looking project_urls.Homepage before a non-repo info.home_page', () => {
     const r = classifyProjectUrls(
       { Homepage: 'https://github.com/psf/requests' },
       'https://primary.example',
     )
     expect(r.repositoryCandidates).toEqual([
       { field: 'homepage', url: 'https://github.com/psf/requests' },
+      { field: 'homepage', url: 'https://primary.example' },
     ])
   })
 

--- a/services/apps/packages_worker/src/pypi/__tests__/upsertProject.test.ts
+++ b/services/apps/packages_worker/src/pypi/__tests__/upsertProject.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  getOrCreateRepoByUrl,
+  removeDeclaredPackageRepo,
+  upsertNpmFundingLinks,
+  upsertPackageMaintainers,
+  upsertPackageRepo,
+  upsertPypiPackage,
+  upsertPypiVersions,
+} from '@crowd/data-access-layer/src/packages'
+import type { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
+
+import type { PyPiProject } from '../types'
+import { upsertProject } from '../upsertProject'
+
+vi.mock('@crowd/data-access-layer/src/packages', () => ({
+  upsertPypiPackage: vi.fn(),
+  upsertPypiVersions: vi.fn().mockResolvedValue([]),
+  getOrCreateRepoByUrl: vi.fn(),
+  upsertPackageRepo: vi.fn().mockResolvedValue([]),
+  removeDeclaredPackageRepo: vi.fn().mockResolvedValue([]),
+  upsertPackageMaintainers: vi.fn().mockResolvedValue([]),
+  upsertNpmFundingLinks: vi.fn().mockResolvedValue([]),
+}))
+
+const mockUpsertPackage = vi.mocked(upsertPypiPackage)
+const mockGetOrCreateRepo = vi.mocked(getOrCreateRepoByUrl)
+const mockUpsertPackageRepo = vi.mocked(upsertPackageRepo)
+const mockRemoveDeclared = vi.mocked(removeDeclaredPackageRepo)
+const mockUpsertVersions = vi.mocked(upsertPypiVersions)
+const mockUpsertMaintainers = vi.mocked(upsertPackageMaintainers)
+const mockUpsertFunding = vi.mocked(upsertNpmFundingLinks)
+
+const qx = {
+  tx: vi.fn((cb: (t: QueryExecutor) => Promise<void>) => cb(qx)),
+} as unknown as QueryExecutor
+const PURL = 'pkg:pypi/flask'
+
+const baseProject = (info: Partial<PyPiProject['info']>): PyPiProject => ({
+  info: { name: 'flask', ...info },
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUpsertPackage.mockResolvedValue({ id: '1', changedFields: [] })
+  mockGetOrCreateRepo.mockResolvedValue({ id: '2', changedFields: [] })
+})
+
+describe('upsertProject — declaredRepositoryUrl', () => {
+  it('stores the source candidate as declaredRepositoryUrl', async () => {
+    await upsertProject(
+      qx,
+      baseProject({ project_urls: { Source: 'https://github.com/pallets/flask' } }),
+      PURL,
+    )
+
+    expect(mockUpsertPackage).toHaveBeenCalledWith(
+      qx,
+      expect.objectContaining({ declaredRepositoryUrl: 'https://github.com/pallets/flask' }),
+    )
+  })
+
+  it('does not surface a homepage-only fallback candidate as declaredRepositoryUrl', async () => {
+    await upsertProject(
+      qx,
+      baseProject({ project_urls: { Homepage: 'https://github.com/psf/requests' } }),
+      PURL,
+    )
+
+    expect(mockUpsertPackage).toHaveBeenCalledWith(
+      qx,
+      expect.objectContaining({ declaredRepositoryUrl: null }),
+    )
+  })
+
+  it('does not surface a bug-tracker-only fallback candidate as declaredRepositoryUrl', async () => {
+    await upsertProject(
+      qx,
+      baseProject({ project_urls: { 'Bug Tracker': 'https://github.com/foo/bar/issues' } }),
+      PURL,
+    )
+
+    expect(mockUpsertPackage).toHaveBeenCalledWith(
+      qx,
+      expect.objectContaining({ declaredRepositoryUrl: null }),
+    )
+  })
+})
+
+describe('upsertProject — homepage repo candidate', () => {
+  it('keeps a repo-looking project_urls.Homepage as a candidate even when info.home_page overrides packages.homepage', async () => {
+    await upsertProject(
+      qx,
+      baseProject({
+        home_page: 'https://docs.example.org',
+        project_urls: { Homepage: 'https://github.com/org/repo' },
+      }),
+      PURL,
+    )
+
+    expect(mockUpsertPackage).toHaveBeenCalledWith(
+      qx,
+      expect.objectContaining({ homepage: 'https://docs.example.org' }),
+    )
+    expect(mockGetOrCreateRepo).toHaveBeenCalledWith(
+      qx,
+      'https://github.com/org/repo',
+      expect.anything(),
+    )
+  })
+})

--- a/services/apps/packages_worker/src/pypi/__tests__/upsertProject.test.ts
+++ b/services/apps/packages_worker/src/pypi/__tests__/upsertProject.test.ts
@@ -1,14 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import {
-  getOrCreateRepoByUrl,
-  removeDeclaredPackageRepo,
-  upsertNpmFundingLinks,
-  upsertPackageMaintainers,
-  upsertPackageRepo,
-  upsertPypiPackage,
-  upsertPypiVersions,
-} from '@crowd/data-access-layer/src/packages'
+import { getOrCreateRepoByUrl, upsertPypiPackage } from '@crowd/data-access-layer/src/packages'
 import type { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
 import type { PyPiProject } from '../types'
@@ -26,11 +18,6 @@ vi.mock('@crowd/data-access-layer/src/packages', () => ({
 
 const mockUpsertPackage = vi.mocked(upsertPypiPackage)
 const mockGetOrCreateRepo = vi.mocked(getOrCreateRepoByUrl)
-const mockUpsertPackageRepo = vi.mocked(upsertPackageRepo)
-const mockRemoveDeclared = vi.mocked(removeDeclaredPackageRepo)
-const mockUpsertVersions = vi.mocked(upsertPypiVersions)
-const mockUpsertMaintainers = vi.mocked(upsertPackageMaintainers)
-const mockUpsertFunding = vi.mocked(upsertNpmFundingLinks)
 
 const qx = {
   tx: vi.fn((cb: (t: QueryExecutor) => Promise<void>) => cb(qx)),

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -184,6 +184,8 @@ export function collectPypiMaintainers(info: PyPiInfo): PypiPerson[] {
   return [...map.values()]
 }
 
+export type PypiRepositoryField = 'source' | 'homepage' | 'bug_tracker'
+
 export interface PypiFundingLink {
   type: string
   url: string
@@ -204,6 +206,7 @@ export function classifyProjectUrls(
 ): {
   homepage: string | null
   declaredRepositoryUrl: string | null
+  declaredRepositoryField: PypiRepositoryField | null
   fundingLinks: PypiFundingLink[]
 } {
   const entries = Object.entries(projectUrls ?? {}).map(
@@ -226,9 +229,18 @@ export function classifyProjectUrls(
     findByKey(/^code$/i) ??
     entries.find(([k, v]) => /source|repo|code|git/i.test(k) && REPO_HOST.test(v))?.[1] ??
     null
-  // Many projects only declare a Homepage that is itself the repo.
+  let declaredRepositoryField: PypiRepositoryField | null = declaredRepositoryUrl ? 'source' : null
+  // Many projects only declare a Homepage, or only a Bug Tracker, that is itself the repo.
   if (!declaredRepositoryUrl && homepage && REPO_HOST.test(homepage)) {
     declaredRepositoryUrl = homepage
+    declaredRepositoryField = 'homepage'
+  }
+  if (!declaredRepositoryUrl) {
+    const tracker = entries.find(([k, v]) => /bug|issue|tracker/i.test(k) && REPO_HOST.test(v))?.[1]
+    if (tracker) {
+      declaredRepositoryUrl = tracker
+      declaredRepositoryField = 'bug_tracker'
+    }
   }
 
   const seen = new Set<string>()
@@ -239,7 +251,7 @@ export function classifyProjectUrls(
     fundingLinks.push({ type: inferFundingType(v), url: v })
   }
 
-  return { homepage, declaredRepositoryUrl, fundingLinks }
+  return { homepage, declaredRepositoryUrl, declaredRepositoryField, fundingLinks }
 }
 
 export function parseKeywords(raw: string | null | undefined): string[] {

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -227,7 +227,10 @@ export function classifyProjectUrls(
     findByKey(/^repository$/i) ??
     findByKey(/^repo$/i) ??
     findByKey(/^code$/i) ??
-    entries.find(([k, v]) => /source|repo|code|\bgit\b/i.test(k) && REPO_HOST.test(v) && !/bug|issue|tracker/i.test(k))?.[1] ??
+    entries.find(
+      ([k, v]) =>
+        /source|repo|code|\bgit\b/i.test(k) && REPO_HOST.test(v) && !/bug|issue|tracker/i.test(k),
+    )?.[1] ??
     null
   let declaredRepositoryField: PypiRepositoryField | null = declaredRepositoryUrl ? 'source' : null
   // Many projects only declare a Homepage, or only a Bug Tracker, that is itself the repo.

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -227,7 +227,7 @@ export function classifyProjectUrls(
     findByKey(/^repository$/i) ??
     findByKey(/^repo$/i) ??
     findByKey(/^code$/i) ??
-    entries.find(([k, v]) => /source|repo|code|git/i.test(k) && REPO_HOST.test(v))?.[1] ??
+    entries.find(([k, v]) => /source|repo|code|\bgit\b/i.test(k) && REPO_HOST.test(v) && !/bug|issue|tracker/i.test(k))?.[1] ??
     null
   let declaredRepositoryField: PypiRepositoryField | null = declaredRepositoryUrl ? 'source' : null
   // Many projects only declare a Homepage, or only a Bug Tracker, that is itself the repo.

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -234,12 +234,14 @@ export function classifyProjectUrls(
     findByKey(/^repository$/i),
     findByKey(/^repo$/i),
     findByKey(/^code$/i),
-    entries.find(
-      ([k, v]) =>
-        /source|repo|code|git/i.test(k) &&
-        !/bug|issue|tracker/i.test(k) &&
-        canonicalizeRepoUrl(v) !== null,
-    )?.[1] ?? null,
+    ...entries
+      .filter(
+        ([k, v]) =>
+          /source|repo|code|git/i.test(k) &&
+          !/bug|issue|tracker/i.test(k) &&
+          canonicalizeRepoUrl(v) !== null,
+      )
+      .map(([, v]) => v),
   ].filter((v): v is string => v !== null)
   const seenSourceUrls = new Set<string>()
   const sourceUrls = sourceUrlCandidates.filter(

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -241,8 +241,7 @@ export function classifyProjectUrls(
 
   const repositoryCandidates: PypiRepoCandidate[] = []
   if (sourceUrl) repositoryCandidates.push({ field: 'source', url: sourceUrl })
-  // Passed through raw, untested — the shared resolver's own host==='other' gate rejects
-  // non-repositories, same as every other resolveManifestRepo caller. project_urls.Homepage
+  // Passed through raw, untested, per resolveManifestRepo convention. project_urls.Homepage
   // goes first so a non-repo info.home_page can't mask it.
   const rawHomePage = blankToNull(homePage)
   if (projectUrlsHomepage)

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -223,10 +223,8 @@ export function classifyProjectUrls(
     findByKey(/^homepage$/i) ?? findByKey(/^home[\s-]*page$/i) ?? findByKey(/^home$/i)
   const homepage = blankToNull(homePage) ?? projectUrlsHomepage
 
-  // Candidates are ordered by trust, most trusted first — a project can declare a Source
-  // field AND a Homepage/Bug Tracker that also happen to point at a repo host. Keeping all
-  // of them (rather than picking one before validation) lets the caller fall through to the
-  // next candidate when the top pick fails canonicalization (malformed URL, unsupported path).
+  // Candidates are ordered by trust, most trusted first, and all kept (not picked early) so
+  // the caller can fall through past a top pick that fails canonicalization.
   const REPO_HOST = /github\.com|gitlab\.com|bitbucket\.org/i
   const sourceUrl =
     findByKey(/^source(\s*code)?$/i) ??
@@ -243,15 +241,13 @@ export function classifyProjectUrls(
 
   const repositoryCandidates: PypiRepoCandidate[] = []
   if (sourceUrl) repositoryCandidates.push({ field: 'source', url: sourceUrl })
-  // Checked against project_urls.Homepage specifically, not the resolved `homepage` above —
-  // a non-repository info.home_page (e.g. a docs site) takes precedence for `packages.homepage`
-  // but must not mask a repo-looking project_urls.Homepage as a repository candidate.
+  // Checked against project_urls.Homepage directly, not the resolved `homepage` above — a
+  // non-repo info.home_page must not mask a repo-looking project_urls.Homepage candidate.
   if (projectUrlsHomepage && REPO_HOST.test(projectUrlsHomepage)) {
     repositoryCandidates.push({ field: 'homepage', url: projectUrlsHomepage })
   }
-  // Included even when a source URL is already a candidate: a malformed/unsupported source
-  // is dropped by the resolver at canonicalization time, not here, so the tracker must stay
-  // available as a fallback for the resolver to fall through to.
+  // Kept even with a source candidate already present — a malformed source is dropped at
+  // canonicalization, not here, so the tracker stays available for the resolver to fall to.
   if (trackerUrl) repositoryCandidates.push({ field: 'bug_tracker', url: trackerUrl })
 
   const seen = new Set<string>()

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -226,21 +226,28 @@ export function classifyProjectUrls(
   // Candidates are ordered by trust, most trusted first, and all kept (not picked early) so
   // the caller can fall through past a top pick that fails canonicalization.
   const REPO_HOST = /github\.com|gitlab\.com|bitbucket\.org/i
-  const sourceUrl =
-    findByKey(/^source(\s*code)?$/i) ??
-    findByKey(/^repository$/i) ??
-    findByKey(/^repo$/i) ??
-    findByKey(/^code$/i) ??
+  // Every source-shaped field is kept, not just the first `??` winner, so a malformed alias
+  // (e.g. Source: not-a-url) can't hide a later valid one from the resolver.
+  const sourceUrlCandidates = [
+    findByKey(/^source(\s*code)?$/i),
+    findByKey(/^repository$/i),
+    findByKey(/^repo$/i),
+    findByKey(/^code$/i),
     entries.find(
       ([k, v]) =>
         /source|repo|code|git/i.test(k) && REPO_HOST.test(v) && !/bug|issue|tracker/i.test(k),
-    )?.[1] ??
-    null
-  const trackerUrl =
-    entries.find(([k, v]) => /bug|issue|tracker/i.test(k) && REPO_HOST.test(v))?.[1] ?? null
+    )?.[1] ?? null,
+  ].filter((v): v is string => v !== null)
+  const seenSourceUrls = new Set<string>()
+  const sourceUrls = sourceUrlCandidates.filter(
+    (url) => !seenSourceUrls.has(url) && seenSourceUrls.add(url),
+  )
+  // Passed raw per resolveManifestRepo convention — canonicalizeRepoUrl handles recognized-host
+  // forms like `github:foo/bar/issues`; prefiltering by hostname here would drop those.
+  const trackerUrl = entries.find(([k, v]) => /bug|issue|tracker/i.test(k) && v)?.[1] ?? null
 
   const repositoryCandidates: PypiRepoCandidate[] = []
-  if (sourceUrl) repositoryCandidates.push({ field: 'source', url: sourceUrl })
+  for (const url of sourceUrls) repositoryCandidates.push({ field: 'source', url })
   // Passed through raw, untested, per resolveManifestRepo convention. project_urls.Homepage
   // goes first so a non-repo info.home_page can't mask it.
   const rawHomePage = blankToNull(homePage)

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -237,7 +237,7 @@ export function classifyProjectUrls(
     findByKey(/^code$/i) ??
     entries.find(
       ([k, v]) =>
-        /source|repo|code|\bgit\b/i.test(k) && REPO_HOST.test(v) && !/bug|issue|tracker/i.test(k),
+        /source|repo|code|git/i.test(k) && REPO_HOST.test(v) && !/bug|issue|tracker/i.test(k),
     )?.[1] ??
     null
   const trackerUrl =

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -248,7 +248,10 @@ export function classifyProjectUrls(
   if (homepage && REPO_HOST.test(homepage)) {
     repositoryCandidates.push({ field: 'homepage', url: homepage })
   }
-  if (trackerUrl && !sourceUrl) repositoryCandidates.push({ field: 'bug_tracker', url: trackerUrl })
+  // Included even when a source URL is already a candidate: a malformed/unsupported source
+  // is dropped by the resolver at canonicalization time, not here, so the tracker must stay
+  // available as a fallback for the resolver to fall through to.
+  if (trackerUrl) repositoryCandidates.push({ field: 'bug_tracker', url: trackerUrl })
 
   const seen = new Set<string>()
   const fundingLinks: PypiFundingLink[] = []

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -245,7 +245,8 @@ export function classifyProjectUrls(
   // non-repositories, same as every other resolveManifestRepo caller. project_urls.Homepage
   // goes first so a non-repo info.home_page can't mask it.
   const rawHomePage = blankToNull(homePage)
-  if (projectUrlsHomepage) repositoryCandidates.push({ field: 'homepage', url: projectUrlsHomepage })
+  if (projectUrlsHomepage)
+    repositoryCandidates.push({ field: 'homepage', url: projectUrlsHomepage })
   if (rawHomePage && rawHomePage !== projectUrlsHomepage) {
     repositoryCandidates.push({ field: 'homepage', url: rawHomePage })
   }

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -219,11 +219,9 @@ export function classifyProjectUrls(
   const findByKey = (re: RegExp): string | null =>
     entries.find(([k, v]) => re.test(k) && v)?.[1] ?? null
 
-  const homepage =
-    blankToNull(homePage) ??
-    findByKey(/^homepage$/i) ??
-    findByKey(/^home[\s-]*page$/i) ??
-    findByKey(/^home$/i)
+  const projectUrlsHomepage =
+    findByKey(/^homepage$/i) ?? findByKey(/^home[\s-]*page$/i) ?? findByKey(/^home$/i)
+  const homepage = blankToNull(homePage) ?? projectUrlsHomepage
 
   // Candidates are ordered by trust, most trusted first — a project can declare a Source
   // field AND a Homepage/Bug Tracker that also happen to point at a repo host. Keeping all
@@ -245,8 +243,11 @@ export function classifyProjectUrls(
 
   const repositoryCandidates: PypiRepoCandidate[] = []
   if (sourceUrl) repositoryCandidates.push({ field: 'source', url: sourceUrl })
-  if (homepage && REPO_HOST.test(homepage)) {
-    repositoryCandidates.push({ field: 'homepage', url: homepage })
+  // Checked against project_urls.Homepage specifically, not the resolved `homepage` above —
+  // a non-repository info.home_page (e.g. a docs site) takes precedence for `packages.homepage`
+  // but must not mask a repo-looking project_urls.Homepage as a repository candidate.
+  if (projectUrlsHomepage && REPO_HOST.test(projectUrlsHomepage)) {
+    repositoryCandidates.push({ field: 'homepage', url: projectUrlsHomepage })
   }
   // Included even when a source URL is already a candidate: a malformed/unsupported source
   // is dropped by the resolver at canonicalization time, not here, so the tracker must stay

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -225,10 +225,8 @@ export function classifyProjectUrls(
     findByKey(/^homepage$/i) ?? findByKey(/^home[\s-]*page$/i) ?? findByKey(/^home$/i)
   const homepage = blankToNull(homePage) ?? projectUrlsHomepage
 
-  // Candidates are ordered by trust, most trusted first, and all kept (not picked early) so
-  // the caller can fall through past a top pick that fails canonicalization.
-  // Every source-shaped field is kept, not just the first `??` winner, so a malformed alias
-  // (e.g. Source: not-a-url) can't hide a later valid one from the resolver.
+  // Ordered most trusted first, all kept so a bad top pick can fall through to a later one;
+  // the fuzzy match stays host-gated to preserve its historical strictness.
   const sourceUrlCandidates = [
     findByKey(/^source(\s*code)?$/i),
     findByKey(/^repository$/i),
@@ -239,7 +237,7 @@ export function classifyProjectUrls(
         ([k, v]) =>
           /source|repo|code|git/i.test(k) &&
           !/bug|issue|tracker/i.test(k) &&
-          canonicalizeRepoUrl(v) !== null,
+          (canonicalizeRepoUrl(v)?.host ?? 'other') !== 'other',
       )
       .map(([, v]) => v),
   ].filter((v): v is string => v !== null)

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -245,9 +245,14 @@ export function classifyProjectUrls(
   const sourceUrls = sourceUrlCandidates.filter(
     (url) => !seenSourceUrls.has(url) && seenSourceUrls.add(url),
   )
-  // Passed raw per resolveManifestRepo convention — canonicalizeRepoUrl handles recognized-host
-  // forms like `github:foo/bar/issues`; prefiltering by hostname here would drop those.
-  const trackerUrl = entries.find(([k, v]) => /bug|issue|tracker/i.test(k) && v)?.[1] ?? null
+  // All matches kept, in original order, so a malformed tracker entry doesn't shadow a later
+  // usable one — passed raw per resolveManifestRepo convention, canonicalizeRepoUrl handles
+  // recognized-host forms like `github:foo/bar/issues`; prefiltering by hostname would drop those.
+  const seenTrackerUrls = new Set<string>()
+  const trackerUrls = entries
+    .filter(([k, v]) => /bug|issue|tracker/i.test(k) && v)
+    .map(([, v]) => v)
+    .filter((url) => !seenTrackerUrls.has(url) && seenTrackerUrls.add(url))
 
   const repositoryCandidates: PypiRepoCandidate[] = []
   for (const url of sourceUrls) repositoryCandidates.push({ field: 'source', url })
@@ -260,8 +265,8 @@ export function classifyProjectUrls(
     repositoryCandidates.push({ field: 'homepage', url: rawHomePage })
   }
   // Kept even with a source candidate already present — a malformed source is dropped at
-  // canonicalization, not here, so the tracker stays available for the resolver to fall to.
-  if (trackerUrl) repositoryCandidates.push({ field: 'bug_tracker', url: trackerUrl })
+  // canonicalization, not here, so a tracker stays available for the resolver to fall to.
+  for (const url of trackerUrls) repositoryCandidates.push({ field: 'bug_tracker', url })
 
   const seen = new Set<string>()
   const fundingLinks: PypiFundingLink[] = []

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -241,15 +241,13 @@ export function classifyProjectUrls(
 
   const repositoryCandidates: PypiRepoCandidate[] = []
   if (sourceUrl) repositoryCandidates.push({ field: 'source', url: sourceUrl })
-  // project_urls.Homepage wins when it looks like a repo; a non-repo info.home_page must not
-  // mask it. Otherwise fall back to info.home_page itself, so a bare repo URL there (with no
-  // matching project_urls.Homepage) still yields a candidate.
+  // Passed through raw, untested — the shared resolver's own host==='other' gate rejects
+  // non-repositories, same as every other resolveManifestRepo caller. project_urls.Homepage
+  // goes first so a non-repo info.home_page can't mask it.
   const rawHomePage = blankToNull(homePage)
-  const homepageRepoUrl =
-    (projectUrlsHomepage && REPO_HOST.test(projectUrlsHomepage) ? projectUrlsHomepage : null) ??
-    (rawHomePage && REPO_HOST.test(rawHomePage) ? rawHomePage : null)
-  if (homepageRepoUrl) {
-    repositoryCandidates.push({ field: 'homepage', url: homepageRepoUrl })
+  if (projectUrlsHomepage) repositoryCandidates.push({ field: 'homepage', url: projectUrlsHomepage })
+  if (rawHomePage && rawHomePage !== projectUrlsHomepage) {
+    repositoryCandidates.push({ field: 'homepage', url: rawHomePage })
   }
   // Kept even with a source candidate already present — a malformed source is dropped at
   // canonicalization, not here, so the tracker stays available for the resolver to fall to.

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -200,13 +200,17 @@ function inferFundingType(url: string): string {
   return 'other'
 }
 
+export interface PypiRepoCandidate {
+  field: PypiRepositoryField
+  url: string
+}
+
 export function classifyProjectUrls(
   projectUrls: Record<string, string> | null | undefined,
   homePage: string | null | undefined,
 ): {
   homepage: string | null
-  declaredRepositoryUrl: string | null
-  declaredRepositoryField: PypiRepositoryField | null
+  repositoryCandidates: PypiRepoCandidate[]
   fundingLinks: PypiFundingLink[]
 } {
   const entries = Object.entries(projectUrls ?? {}).map(
@@ -221,8 +225,12 @@ export function classifyProjectUrls(
     findByKey(/^home[\s-]*page$/i) ??
     findByKey(/^home$/i)
 
+  // Candidates are ordered by trust, most trusted first — a project can declare a Source
+  // field AND a Homepage/Bug Tracker that also happen to point at a repo host. Keeping all
+  // of them (rather than picking one before validation) lets the caller fall through to the
+  // next candidate when the top pick fails canonicalization (malformed URL, unsupported path).
   const REPO_HOST = /github\.com|gitlab\.com|bitbucket\.org/i
-  let declaredRepositoryUrl =
+  const sourceUrl =
     findByKey(/^source(\s*code)?$/i) ??
     findByKey(/^repository$/i) ??
     findByKey(/^repo$/i) ??
@@ -232,19 +240,15 @@ export function classifyProjectUrls(
         /source|repo|code|\bgit\b/i.test(k) && REPO_HOST.test(v) && !/bug|issue|tracker/i.test(k),
     )?.[1] ??
     null
-  let declaredRepositoryField: PypiRepositoryField | null = declaredRepositoryUrl ? 'source' : null
-  // Many projects only declare a Homepage, or only a Bug Tracker, that is itself the repo.
-  if (!declaredRepositoryUrl && homepage && REPO_HOST.test(homepage)) {
-    declaredRepositoryUrl = homepage
-    declaredRepositoryField = 'homepage'
+  const trackerUrl =
+    entries.find(([k, v]) => /bug|issue|tracker/i.test(k) && REPO_HOST.test(v))?.[1] ?? null
+
+  const repositoryCandidates: PypiRepoCandidate[] = []
+  if (sourceUrl) repositoryCandidates.push({ field: 'source', url: sourceUrl })
+  if (homepage && REPO_HOST.test(homepage)) {
+    repositoryCandidates.push({ field: 'homepage', url: homepage })
   }
-  if (!declaredRepositoryUrl) {
-    const tracker = entries.find(([k, v]) => /bug|issue|tracker/i.test(k) && REPO_HOST.test(v))?.[1]
-    if (tracker) {
-      declaredRepositoryUrl = tracker
-      declaredRepositoryField = 'bug_tracker'
-    }
-  }
+  if (trackerUrl && !sourceUrl) repositoryCandidates.push({ field: 'bug_tracker', url: trackerUrl })
 
   const seen = new Set<string>()
   const fundingLinks: PypiFundingLink[] = []
@@ -254,7 +258,7 @@ export function classifyProjectUrls(
     fundingLinks.push({ type: inferFundingType(v), url: v })
   }
 
-  return { homepage, declaredRepositoryUrl, declaredRepositoryField, fundingLinks }
+  return { homepage, repositoryCandidates, fundingLinks }
 }
 
 export function parseKeywords(raw: string | null | undefined): string[] {

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -1,3 +1,5 @@
+import { canonicalizeRepoUrl } from '../utils/canonicalizeRepoUrl'
+
 import type { PyPiInfo, PyPiReleaseFile } from './types'
 
 const PURL_PYPI_PREFIX = 'pkg:pypi/'
@@ -225,7 +227,6 @@ export function classifyProjectUrls(
 
   // Candidates are ordered by trust, most trusted first, and all kept (not picked early) so
   // the caller can fall through past a top pick that fails canonicalization.
-  const REPO_HOST = /github\.com|gitlab\.com|bitbucket\.org/i
   // Every source-shaped field is kept, not just the first `??` winner, so a malformed alias
   // (e.g. Source: not-a-url) can't hide a later valid one from the resolver.
   const sourceUrlCandidates = [
@@ -235,7 +236,9 @@ export function classifyProjectUrls(
     findByKey(/^code$/i),
     entries.find(
       ([k, v]) =>
-        /source|repo|code|git/i.test(k) && REPO_HOST.test(v) && !/bug|issue|tracker/i.test(k),
+        /source|repo|code|git/i.test(k) &&
+        !/bug|issue|tracker/i.test(k) &&
+        canonicalizeRepoUrl(v) !== null,
     )?.[1] ?? null,
   ].filter((v): v is string => v !== null)
   const seenSourceUrls = new Set<string>()

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -245,9 +245,8 @@ export function classifyProjectUrls(
   const sourceUrls = sourceUrlCandidates.filter(
     (url) => !seenSourceUrls.has(url) && seenSourceUrls.add(url),
   )
-  // All matches kept, in original order, so a malformed tracker entry doesn't shadow a later
-  // usable one — passed raw per resolveManifestRepo convention, canonicalizeRepoUrl handles
-  // recognized-host forms like `github:foo/bar/issues`; prefiltering by hostname would drop those.
+  // All matches kept in order so a malformed tracker entry doesn't shadow a usable one — passed
+  // raw so canonicalizeRepoUrl can still resolve recognized-host forms like `github:foo/bar/issues`.
   const seenTrackerUrls = new Set<string>()
   const trackerUrls = entries
     .filter(([k, v]) => /bug|issue|tracker/i.test(k) && v)

--- a/services/apps/packages_worker/src/pypi/normalize.ts
+++ b/services/apps/packages_worker/src/pypi/normalize.ts
@@ -241,10 +241,15 @@ export function classifyProjectUrls(
 
   const repositoryCandidates: PypiRepoCandidate[] = []
   if (sourceUrl) repositoryCandidates.push({ field: 'source', url: sourceUrl })
-  // Checked against project_urls.Homepage directly, not the resolved `homepage` above — a
-  // non-repo info.home_page must not mask a repo-looking project_urls.Homepage candidate.
-  if (projectUrlsHomepage && REPO_HOST.test(projectUrlsHomepage)) {
-    repositoryCandidates.push({ field: 'homepage', url: projectUrlsHomepage })
+  // project_urls.Homepage wins when it looks like a repo; a non-repo info.home_page must not
+  // mask it. Otherwise fall back to info.home_page itself, so a bare repo URL there (with no
+  // matching project_urls.Homepage) still yields a candidate.
+  const rawHomePage = blankToNull(homePage)
+  const homepageRepoUrl =
+    (projectUrlsHomepage && REPO_HOST.test(projectUrlsHomepage) ? projectUrlsHomepage : null) ??
+    (rawHomePage && REPO_HOST.test(rawHomePage) ? rawHomePage : null)
+  if (homepageRepoUrl) {
+    repositoryCandidates.push({ field: 'homepage', url: homepageRepoUrl })
   }
   // Kept even with a source candidate already present — a malformed source is dropped at
   // canonicalization, not here, so the tracker stays available for the resolver to fall to.

--- a/services/apps/packages_worker/src/pypi/upsertProject.ts
+++ b/services/apps/packages_worker/src/pypi/upsertProject.ts
@@ -6,6 +6,7 @@ import {
   upsertPypiPackage,
   upsertPypiVersions,
 } from '@crowd/data-access-layer/src/packages'
+import type { PackageRepoSignal } from '@crowd/data-access-layer/src/packages/repoConfidence'
 import type { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
 import { canonicalizeRepoUrl } from '../utils/canonicalizeRepoUrl'
@@ -37,11 +38,11 @@ export async function upsertProject(
     `https://pypi.org/project/${pypiName}/`
   const description = info.summary?.trim() ? info.summary.trim() : null
 
-  const { homepage, declaredRepositoryUrl, fundingLinks } = classifyProjectUrls(
-    info.project_urls,
-    info.home_page,
-  )
+  const { homepage, declaredRepositoryUrl, declaredRepositoryField, fundingLinks } =
+    classifyProjectUrls(info.project_urls, info.home_page)
   const repo = declaredRepositoryUrl ? canonicalizeRepoUrl(declaredRepositoryUrl) : null
+  const repoSignal: PackageRepoSignal =
+    declaredRepositoryField === 'source' ? 'primary' : 'secondary'
   const { licenses, licensesRaw } = resolvePypiLicenses(info)
   const keywords = parseKeywords(info.keywords)
   const maintainers = collectPypiMaintainers(info)
@@ -86,7 +87,10 @@ export async function upsertProject(
         repo.host,
       )
       repoChanged.forEach((f) => changed.add(f))
-      const linkChanged = await upsertPackageRepo(t, pkgId, repoId, { source: 'declared' })
+      const linkChanged = await upsertPackageRepo(t, pkgId, repoId, {
+        source: 'declared',
+        signal: repoSignal,
+      })
       linkChanged.forEach((f) => changed.add(f))
     }
 

--- a/services/apps/packages_worker/src/pypi/upsertProject.ts
+++ b/services/apps/packages_worker/src/pypi/upsertProject.ts
@@ -1,5 +1,6 @@
 import {
   getOrCreateRepoByUrl,
+  removeDeclaredPackageRepo,
   upsertNpmFundingLinks,
   upsertPackageMaintainers,
   upsertPackageRepo,
@@ -80,7 +81,7 @@ export async function upsertProject(
     })
     pkgChanged.forEach((f) => changed.add(f))
 
-    if (repo) {
+    if (repo && (repoSignal === 'primary' || repo.host !== 'other')) {
       const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(
         t,
         repo.url,
@@ -92,6 +93,12 @@ export async function upsertProject(
         signal: repoSignal,
       })
       linkChanged.forEach((f) => changed.add(f))
+
+      const removedFields = await removeDeclaredPackageRepo(t, pkgId, repoId)
+      removedFields.forEach((f) => changed.add(f))
+    } else {
+      const removedFields = await removeDeclaredPackageRepo(t, pkgId)
+      removedFields.forEach((f) => changed.add(f))
     }
 
     if (versionRows.length > 0) {

--- a/services/apps/packages_worker/src/pypi/upsertProject.ts
+++ b/services/apps/packages_worker/src/pypi/upsertProject.ts
@@ -41,7 +41,9 @@ export async function upsertProject(
 
   const { homepage, declaredRepositoryUrl, declaredRepositoryField, fundingLinks } =
     classifyProjectUrls(info.project_urls, info.home_page)
-  const repoCanonicalized = declaredRepositoryUrl ? canonicalizeRepoUrl(declaredRepositoryUrl) : null
+  const repoCanonicalized = declaredRepositoryUrl
+    ? canonicalizeRepoUrl(declaredRepositoryUrl)
+    : null
   const repoSignal: PackageRepoSignal =
     declaredRepositoryField === 'source' ? 'primary' : 'secondary'
   const repo =

--- a/services/apps/packages_worker/src/pypi/upsertProject.ts
+++ b/services/apps/packages_worker/src/pypi/upsertProject.ts
@@ -41,9 +41,13 @@ export async function upsertProject(
 
   const { homepage, declaredRepositoryUrl, declaredRepositoryField, fundingLinks } =
     classifyProjectUrls(info.project_urls, info.home_page)
-  const repo = declaredRepositoryUrl ? canonicalizeRepoUrl(declaredRepositoryUrl) : null
+  const repoCanonicalized = declaredRepositoryUrl ? canonicalizeRepoUrl(declaredRepositoryUrl) : null
   const repoSignal: PackageRepoSignal =
     declaredRepositoryField === 'source' ? 'primary' : 'secondary'
+  const repo =
+    repoCanonicalized && (repoSignal === 'primary' || repoCanonicalized.host !== 'other')
+      ? repoCanonicalized
+      : null
   const { licenses, licensesRaw } = resolvePypiLicenses(info)
   const keywords = parseKeywords(info.keywords)
   const maintainers = collectPypiMaintainers(info)
@@ -81,7 +85,7 @@ export async function upsertProject(
     })
     pkgChanged.forEach((f) => changed.add(f))
 
-    if (repo && (repoSignal === 'primary' || repo.host !== 'other')) {
+    if (repo) {
       const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(
         t,
         repo.url,

--- a/services/apps/packages_worker/src/pypi/upsertProject.ts
+++ b/services/apps/packages_worker/src/pypi/upsertProject.ts
@@ -10,7 +10,7 @@ import {
 import type { PackageRepoSignal } from '@crowd/data-access-layer/src/packages/repoConfidence'
 import type { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
-import { canonicalizeRepoUrl } from '../utils/canonicalizeRepoUrl'
+import { resolveManifestRepo } from '../utils/resolveManifestRepo'
 import { stripNullBytesDeep } from '../utils/stripNullBytesDeep'
 
 import {
@@ -39,17 +39,20 @@ export async function upsertProject(
     `https://pypi.org/project/${pypiName}/`
   const description = info.summary?.trim() ? info.summary.trim() : null
 
-  const { homepage, declaredRepositoryUrl, declaredRepositoryField, fundingLinks } =
-    classifyProjectUrls(info.project_urls, info.home_page)
-  const repoCanonicalized = declaredRepositoryUrl
-    ? canonicalizeRepoUrl(declaredRepositoryUrl)
-    : null
-  const repoSignal: PackageRepoSignal =
-    declaredRepositoryField === 'source' ? 'primary' : 'secondary'
-  const repo =
-    repoCanonicalized && (repoSignal === 'primary' || repoCanonicalized.host !== 'other')
-      ? repoCanonicalized
-      : null
+  const { homepage, repositoryCandidates, fundingLinks } = classifyProjectUrls(
+    info.project_urls,
+    info.home_page,
+  )
+  const declaredRepositoryUrl = repositoryCandidates[0]?.url ?? null
+  const resolvedRepo = resolveManifestRepo(
+    repositoryCandidates.map((candidate) => ({
+      field: candidate.field,
+      url: candidate.url,
+      signal: candidate.field === 'source' ? 'primary' : 'secondary',
+    })),
+  )
+  const repo = resolvedRepo?.repo ?? null
+  const repoSignal: PackageRepoSignal = resolvedRepo?.signal ?? 'primary'
   const { licenses, licensesRaw } = resolvePypiLicenses(info)
   const keywords = parseKeywords(info.keywords)
   const maintainers = collectPypiMaintainers(info)

--- a/services/apps/packages_worker/src/pypi/upsertProject.ts
+++ b/services/apps/packages_worker/src/pypi/upsertProject.ts
@@ -43,7 +43,10 @@ export async function upsertProject(
     info.project_urls,
     info.home_page,
   )
-  const declaredRepositoryUrl = repositoryCandidates[0]?.url ?? null
+  // Only the explicit `source` candidate counts as a declaration — homepage/bug_tracker
+  // are resolver-only fallbacks and must not surface as declaredRepositoryUrl.
+  const declaredRepositoryUrl =
+    repositoryCandidates.find((candidate) => candidate.field === 'source')?.url ?? null
   const resolvedRepo = resolveManifestRepo(
     repositoryCandidates.map((candidate) => ({
       field: candidate.field,

--- a/services/apps/packages_worker/src/rubygems/normalize.ts
+++ b/services/apps/packages_worker/src/rubygems/normalize.ts
@@ -1,4 +1,4 @@
-import { canonicalizeRepoUrl } from '../utils/canonicalizeRepoUrl'
+import { resolveManifestRepo } from '../utils/resolveManifestRepo'
 
 import {
   NormalizedRubyGemsOwner,
@@ -27,7 +27,11 @@ export function normalizeRubyGemsPackage(doc: RubyGemsGemResponse): NormalizedRu
     description: nonEmpty(doc.info),
     homepage: nonEmpty(doc.homepage_uri),
     declaredRepositoryUrl,
-    repo: declaredRepositoryUrl ? canonicalizeRepoUrl(declaredRepositoryUrl) : null,
+    resolvedRepo: resolveManifestRepo([
+      { field: 'source_code_uri', url: declaredRepositoryUrl },
+      { field: 'homepage_uri', url: doc.homepage_uri },
+      { field: 'bug_tracker_uri', url: doc.bug_tracker_uri },
+    ]),
     licenses,
     licensesRaw: licenses ? licenses.join(', ') : null,
     latestVersion: nonEmpty(doc.version),

--- a/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
+++ b/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
@@ -5,6 +5,7 @@ import {
   listRubyGemsPackagesToSync,
   logAuditFieldChange,
   recordDownloadSnapshot,
+  removeDeclaredPackageRepo,
   upsertPackage,
   upsertPackageRepo,
 } from '@crowd/data-access-layer'
@@ -131,6 +132,12 @@ async function processPackage(
           signal: normalized.resolvedRepo.signal,
         })
         linkChanged.forEach((f) => changed.add(f))
+
+        const removedFields = await removeDeclaredPackageRepo(t, packageDbId.toString(), repoId)
+        removedFields.forEach((f) => changed.add(f))
+      } else {
+        const removedFields = await removeDeclaredPackageRepo(t, packageDbId.toString())
+        removedFields.forEach((f) => changed.add(f))
       }
 
       if (normalized.totalDownloads > 0) {

--- a/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
+++ b/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
@@ -109,7 +109,7 @@ async function processPackage(
         description: normalized.description,
         homepage: normalized.homepage,
         declaredRepositoryUrl: normalized.declaredRepositoryUrl,
-        repositoryUrl: normalized.repo?.url ?? null,
+        repositoryUrl: normalized.resolvedRepo?.repo.url ?? null,
         licenses: normalized.licenses,
         licensesRaw: normalized.licensesRaw,
         latestVersion: normalized.latestVersion,
@@ -118,16 +118,17 @@ async function processPackage(
       })
       pkgChanged.forEach((f) => changed.add(f))
 
-      if (normalized.repo) {
+      if (normalized.resolvedRepo) {
         const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(
           t,
-          normalized.repo.url,
-          normalized.repo.host,
+          normalized.resolvedRepo.repo.url,
+          normalized.resolvedRepo.repo.host,
         )
         repoChanged.forEach((f) => changed.add(f))
 
         const linkChanged = await upsertPackageRepo(t, packageDbId.toString(), repoId, {
           source: 'declared',
+          signal: normalized.resolvedRepo.signal,
         })
         linkChanged.forEach((f) => changed.add(f))
       }

--- a/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
+++ b/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
@@ -6,6 +6,7 @@ import {
   logAuditFieldChange,
   recordDownloadSnapshot,
   removeDeclaredPackageRepo,
+  setPackageRepositoryUrl,
   upsertPackage,
   upsertPackageRepo,
 } from '@crowd/data-access-layer'
@@ -138,6 +139,8 @@ async function processPackage(
       } else {
         const removedFields = await removeDeclaredPackageRepo(t, packageDbId.toString())
         removedFields.forEach((f) => changed.add(f))
+        const clearedFields = await setPackageRepositoryUrl(t, packageDbId.toString(), null)
+        clearedFields.forEach((f) => changed.add(f))
       }
 
       if (normalized.totalDownloads > 0) {

--- a/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
+++ b/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
@@ -121,9 +121,8 @@ async function processPackage(
       })
       pkgChanged.forEach((f) => changed.add(f))
 
-      // upsertPackage's COALESCE can't tell "no source_code_uri this refresh" from "unknown" —
-      // this registry fetch just succeeded, so declaredRepositoryUrl is authoritative; clear it
-      // explicitly when gone.
+      // upsertPackage's COALESCE can't distinguish a dropped source_code_uri from "unknown" —
+      // this registry fetch just succeeded, so clear declaredRepositoryUrl explicitly when gone.
       const declaredClearedFields = await setPackageDeclaredRepositoryUrl(
         t,
         packageDbId.toString(),

--- a/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
+++ b/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
@@ -6,6 +6,7 @@ import {
   logAuditFieldChange,
   recordDownloadSnapshot,
   removeDeclaredPackageRepo,
+  setPackageDeclaredRepositoryUrl,
   setPackageRepositoryUrl,
   upsertPackage,
   upsertPackageRepo,
@@ -119,6 +120,16 @@ async function processPackage(
         ingestionSource: 'rubygems-registry',
       })
       pkgChanged.forEach((f) => changed.add(f))
+
+      // upsertPackage's COALESCE can't tell "no source_code_uri this refresh" from "unknown" —
+      // this registry fetch just succeeded, so declaredRepositoryUrl is authoritative; clear it
+      // explicitly when gone.
+      const declaredClearedFields = await setPackageDeclaredRepositoryUrl(
+        t,
+        packageDbId.toString(),
+        normalized.declaredRepositoryUrl,
+      )
+      declaredClearedFields.forEach((f) => changed.add(f))
 
       if (normalized.resolvedRepo) {
         const { id: repoId, changedFields: repoChanged } = await getOrCreateRepoByUrl(

--- a/services/apps/packages_worker/src/rubygems/types.ts
+++ b/services/apps/packages_worker/src/rubygems/types.ts
@@ -1,4 +1,4 @@
-import { CanonicalRepo } from '../utils/canonicalizeRepoUrl'
+import { ResolvedManifestRepo } from '../utils/resolveManifestRepo'
 
 export interface BatchResult {
   processed: number
@@ -25,6 +25,7 @@ export interface RubyGemsGemResponse {
   info?: string | null
   homepage_uri?: string | null
   source_code_uri?: string | null
+  bug_tracker_uri?: string | null
   licenses?: string[] | null
   downloads?: number
 }
@@ -46,7 +47,7 @@ export interface NormalizedRubyGemsPackage {
   description: string | null
   homepage: string | null
   declaredRepositoryUrl: string | null
-  repo: CanonicalRepo | null
+  resolvedRepo: ResolvedManifestRepo | null
   licenses: string[] | null
   licensesRaw: string | null
   latestVersion: string | null

--- a/services/apps/packages_worker/src/scripts/rescorePackageRepos.ts
+++ b/services/apps/packages_worker/src/scripts/rescorePackageRepos.ts
@@ -2,7 +2,7 @@
 
 /**
  * Recompute package_repos.confidence with package_repo_confidence()
- * (see V1788307200). Used for the initial backfill; the recurring sweep runs as the
+ * (see V1788307300). Used for the initial backfill; the recurring sweep runs as the
  * package-repo-confidence-sweep-daily Temporal schedule.
  *
  * Usage:

--- a/services/apps/packages_worker/src/utils/__tests__/resolveManifestRepo.test.ts
+++ b/services/apps/packages_worker/src/utils/__tests__/resolveManifestRepo.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveManifestRepo } from '../resolveManifestRepo'
+
+describe('resolveManifestRepo', () => {
+  it('resolves the first candidate as primary', () => {
+    expect(
+      resolveManifestRepo([
+        { field: 'repository', url: 'git+https://github.com/babel/babel.git' },
+        { field: 'homepage', url: 'https://github.com/other/repo' },
+      ]),
+    ).toEqual({
+      repo: { url: 'https://github.com/babel/babel', host: 'github' },
+      signal: 'primary',
+      field: 'repository',
+    })
+  })
+
+  it('falls through to the next field when the primary one is missing', () => {
+    expect(
+      resolveManifestRepo([
+        { field: 'repository', url: null },
+        { field: 'homepage', url: 'https://github.com/foo/bar' },
+      ]),
+    ).toEqual({
+      repo: { url: 'https://github.com/foo/bar', host: 'github' },
+      signal: 'secondary',
+      field: 'homepage',
+    })
+  })
+
+  it('falls through when the primary field cannot be canonicalized', () => {
+    const resolved = resolveManifestRepo([
+      { field: 'repository', url: 'not a url' },
+      { field: 'bugs.url', url: 'https://gitlab.com/group/sub/project/-/issues' },
+    ])
+    expect(resolved?.repo.url).toBe('https://gitlab.com/group/sub/project')
+    expect(resolved?.signal).toBe('secondary')
+  })
+
+  it('rejects a secondary candidate that is not on a recognized VCS host', () => {
+    expect(
+      resolveManifestRepo([
+        { field: 'repository', url: null },
+        { field: 'homepage', url: 'https://example.com/docs/getting-started' },
+      ]),
+    ).toBeNull()
+  })
+
+  it('keeps a primary candidate on an unrecognized host', () => {
+    const resolved = resolveManifestRepo([
+      { field: 'repository', url: 'https://git.sr.ht/~sircmpwn/aerc' },
+    ])
+    expect(resolved?.repo.host).toBe('other')
+    expect(resolved?.signal).toBe('primary')
+  })
+
+  it('honours an explicit signal override', () => {
+    expect(
+      resolveManifestRepo([
+        { field: 'homepage', url: 'https://github.com/foo/bar', signal: 'secondary' },
+      ])?.signal,
+    ).toBe('secondary')
+  })
+
+  it('returns null when no candidate resolves', () => {
+    expect(resolveManifestRepo([{ field: 'repository', url: '   ' }])).toBeNull()
+  })
+})

--- a/services/apps/packages_worker/src/utils/__tests__/resolveManifestRepo.test.ts
+++ b/services/apps/packages_worker/src/utils/__tests__/resolveManifestRepo.test.ts
@@ -12,7 +12,6 @@ describe('resolveManifestRepo', () => {
     ).toEqual({
       repo: { url: 'https://github.com/babel/babel', host: 'github' },
       signal: 'primary',
-      field: 'repository',
     })
   })
 
@@ -25,7 +24,6 @@ describe('resolveManifestRepo', () => {
     ).toEqual({
       repo: { url: 'https://github.com/foo/bar', host: 'github' },
       signal: 'secondary',
-      field: 'homepage',
     })
   })
 

--- a/services/apps/packages_worker/src/utils/resolveManifestRepo.ts
+++ b/services/apps/packages_worker/src/utils/resolveManifestRepo.ts
@@ -1,0 +1,45 @@
+import type { PackageRepoSignal } from '@crowd/data-access-layer/src/packages/repoConfidence'
+
+import { CanonicalRepo, canonicalizeRepoUrl } from './canonicalizeRepoUrl'
+
+export interface ManifestRepoCandidate {
+  field: string
+  url: string | null | undefined
+  // Defaults to `primary` for the first candidate and `secondary` for the rest; set it
+  // when the primary field was already resolved elsewhere.
+  signal?: PackageRepoSignal
+}
+
+export interface ResolvedManifestRepo {
+  repo: CanonicalRepo
+  signal: PackageRepoSignal
+  field: string
+}
+
+/**
+ * Resolves a package's repository from the manifest fields that may carry it, in
+ * declaration order: the first candidate is the ecosystem's canonical repository
+ * field (`primary`), every later one a fallback (`secondary`).
+ *
+ * Fallback fields are free-form (homepage, docs, bug tracker), so they are only
+ * accepted on a recognized VCS host — an arbitrary `https://example.com/a/b`
+ * canonicalizes fine but is not a repo. The primary field keeps its historical
+ * behavior and accepts `other` hosts (self-hosted Gitea, cgit, SVN).
+ */
+export function resolveManifestRepo(
+  candidates: ManifestRepoCandidate[],
+): ResolvedManifestRepo | null {
+  for (const [index, candidate] of candidates.entries()) {
+    const raw = candidate.url?.trim()
+    if (!raw) continue
+
+    const repo = canonicalizeRepoUrl(raw)
+    if (!repo) continue
+
+    const signal: PackageRepoSignal = candidate.signal ?? (index === 0 ? 'primary' : 'secondary')
+    if (signal === 'secondary' && repo.host === 'other') continue
+
+    return { repo, signal, field: candidate.field }
+  }
+  return null
+}

--- a/services/apps/packages_worker/src/utils/resolveManifestRepo.ts
+++ b/services/apps/packages_worker/src/utils/resolveManifestRepo.ts
@@ -13,19 +13,8 @@ export interface ManifestRepoCandidate {
 export interface ResolvedManifestRepo {
   repo: CanonicalRepo
   signal: PackageRepoSignal
-  field: string
 }
 
-/**
- * Resolves a package's repository from the manifest fields that may carry it, in
- * declaration order: the first candidate is the ecosystem's canonical repository
- * field (`primary`), every later one a fallback (`secondary`).
- *
- * Fallback fields are free-form (homepage, docs, bug tracker), so they are only
- * accepted on a recognized VCS host — an arbitrary `https://example.com/a/b`
- * canonicalizes fine but is not a repo. The primary field keeps its historical
- * behavior and accepts `other` hosts (self-hosted Gitea, cgit, SVN).
- */
 export function resolveManifestRepo(
   candidates: ManifestRepoCandidate[],
 ): ResolvedManifestRepo | null {
@@ -39,7 +28,7 @@ export function resolveManifestRepo(
     const signal: PackageRepoSignal = candidate.signal ?? (index === 0 ? 'primary' : 'secondary')
     if (signal === 'secondary' && repo.host === 'other') continue
 
-    return { repo, signal, field: candidate.field }
+    return { repo, signal }
   }
   return null
 }

--- a/services/libs/data-access-layer/src/osspckgs/nuget.ts
+++ b/services/libs/data-access-layer/src/osspckgs/nuget.ts
@@ -77,8 +77,9 @@ export async function upsertNuGetPackage(
         description              = COALESCE(EXCLUDED.description,              packages.description),
         homepage                 = COALESCE(EXCLUDED.homepage,                 packages.homepage),
         declared_repository_url  = COALESCE(EXCLUDED.declared_repository_url,  packages.declared_repository_url),
-        repository_url           = COALESCE(EXCLUDED.repository_url,           packages.repository_url,
-                                            packages.declared_repository_url),
+        -- No declared_repository_url fallback: the caller passes NULL to mean "unknown,
+        -- preserve" on a rate limit — falling back would leak the raw, uncanonicalized value in.
+        repository_url           = COALESCE(EXCLUDED.repository_url,           packages.repository_url),
         licenses                 = COALESCE(EXCLUDED.licenses,                 packages.licenses),
         licenses_raw             = COALESCE(EXCLUDED.licenses_raw,             packages.licenses_raw),
         keywords                 = COALESCE(EXCLUDED.keywords,                 packages.keywords),

--- a/services/libs/data-access-layer/src/osspckgs/packages.ts
+++ b/services/libs/data-access-layer/src/osspckgs/packages.ts
@@ -163,6 +163,7 @@ export type MavenRepoUrlRow = {
   id: number
   declaredRepositoryUrl: string | null
   repositoryUrl: string | null
+  homepage: string | null
 }
 
 /**
@@ -185,7 +186,8 @@ export async function listMavenPackagesForRepoUrlRecompute(
     SELECT
       id,
       declared_repository_url AS "declaredRepositoryUrl",
-      repository_url          AS "repositoryUrl"
+      repository_url          AS "repositoryUrl",
+      homepage
     FROM packages
     WHERE ecosystem = 'maven'
       ${options.criticalOnly ? 'AND is_critical' : ''}

--- a/services/libs/data-access-layer/src/packages/packages.ts
+++ b/services/libs/data-access-layer/src/packages/packages.ts
@@ -320,6 +320,19 @@ export async function updatePackagistPackageStats(
   }
 }
 
+export async function setPackageRepositoryUrl(
+  qx: QueryExecutor,
+  packageId: string,
+  url: string,
+): Promise<string[]> {
+  const affected = await qx.result(
+    `UPDATE packages SET repository_url = $(url)
+      WHERE id = $(packageId)::bigint AND repository_url IS DISTINCT FROM $(url)`,
+    { url, packageId },
+  )
+  return affected > 0 ? ['packages.repository_url'] : []
+}
+
 export interface PackagistVersionAggregates {
   versionsCount: number
   latestVersion: string | null

--- a/services/libs/data-access-layer/src/packages/packages.ts
+++ b/services/libs/data-access-layer/src/packages/packages.ts
@@ -270,10 +270,16 @@ export interface PackagistStatsUpdateInput {
 export async function updatePackagistPackageStats(
   qx: QueryExecutor,
   input: PackagistStatsUpdateInput,
-): Promise<{ id: string; isCritical: boolean; changedFields: string[] } | null> {
-  const row: { id: string; is_critical: boolean; changed_fields: string[] } | undefined =
-    await qx.selectOneOrNone(
-      `WITH old AS (
+): Promise<{
+  id: string
+  isCritical: boolean
+  homepage: string | null
+  changedFields: string[]
+} | null> {
+  const row:
+    | { id: string; is_critical: boolean; homepage: string | null; changed_fields: string[] }
+    | undefined = await qx.selectOneOrNone(
+    `WITH old AS (
          SELECT description, declared_repository_url, repository_url, status,
                 total_downloads, dependent_count, ingestion_source
            FROM packages WHERE purl = $(purl) AND ecosystem = 'packagist'
@@ -288,10 +294,10 @@ export async function updatePackagistPackageStats(
            dependent_count           = COALESCE($(dependentCount), dependent_count),
            last_synced_at            = NOW()
          WHERE purl = $(purl) AND ecosystem = 'packagist'
-         RETURNING id, is_critical, description, declared_repository_url, repository_url, status,
-                   total_downloads, dependent_count, ingestion_source
+         RETURNING id, is_critical, homepage, description, declared_repository_url, repository_url,
+                   status, total_downloads, dependent_count, ingestion_source
        )
-       SELECT ins.id::text AS id, ins.is_critical,
+       SELECT ins.id::text AS id, ins.is_critical, ins.homepage,
               array_remove(ARRAY[
                 CASE WHEN o.description               IS DISTINCT FROM ins.description               THEN 'packages.description' END,
                 CASE WHEN o.declared_repository_url   IS DISTINCT FROM ins.declared_repository_url   THEN 'packages.declared_repository_url' END,
@@ -302,11 +308,16 @@ export async function updatePackagistPackageStats(
                 CASE WHEN o.ingestion_source          IS DISTINCT FROM ins.ingestion_source          THEN 'packages.ingestion_source' END
               ], NULL) AS changed_fields
          FROM ins LEFT JOIN old o ON true`,
-      input,
-    )
+    input,
+  )
 
   if (!row) return null
-  return { id: row.id, isCritical: row.is_critical, changedFields: row.changed_fields }
+  return {
+    id: row.id,
+    isCritical: row.is_critical,
+    homepage: row.homepage,
+    changedFields: row.changed_fields,
+  }
 }
 
 export interface PackagistVersionAggregates {

--- a/services/libs/data-access-layer/src/packages/packages.ts
+++ b/services/libs/data-access-layer/src/packages/packages.ts
@@ -322,9 +322,8 @@ export async function setPackageRepositoryUrl(
   packageId: string,
   url: string | null,
 ): Promise<string[]> {
-  // last_synced_at must strictly advance past the caller's upsert, and clock_timestamp()
-  // alone can still tie it at DateTime64(3) resolution — GREATEST with +1ms over the
-  // stored value guarantees a strictly newer CDC version even on that collision.
+  // clock_timestamp() alone can tie last_synced_at at DateTime64(3) resolution — GREATEST
+  // with +1ms over the stored value guarantees a strictly newer CDC version regardless.
   const affected = await qx.result(
     `UPDATE packages
         SET repository_url = $(url),

--- a/services/libs/data-access-layer/src/packages/packages.ts
+++ b/services/libs/data-access-layer/src/packages/packages.ts
@@ -322,10 +322,13 @@ export async function setPackageRepositoryUrl(
   packageId: string,
   url: string | null,
 ): Promise<string[]> {
-  // last_synced_at must strictly advance — clock_timestamp(), not the same-tx NOW() the
-  // caller's upsert already used — or this CDC write loses the ReplacingMergeTree tie.
+  // last_synced_at must strictly advance past the caller's upsert, and clock_timestamp()
+  // alone can still tie it at DateTime64(3) resolution — GREATEST with +1ms over the
+  // stored value guarantees a strictly newer CDC version even on that collision.
   const affected = await qx.result(
-    `UPDATE packages SET repository_url = $(url), last_synced_at = clock_timestamp()
+    `UPDATE packages
+        SET repository_url = $(url),
+            last_synced_at = GREATEST(clock_timestamp(), last_synced_at + interval '1 millisecond')
       WHERE id = $(packageId)::bigint AND repository_url IS DISTINCT FROM $(url)`,
     { url, packageId },
   )

--- a/services/libs/data-access-layer/src/packages/packages.ts
+++ b/services/libs/data-access-layer/src/packages/packages.ts
@@ -322,13 +322,8 @@ export async function setPackageRepositoryUrl(
   packageId: string,
   url: string | null,
 ): Promise<string[]> {
-  // repository_url is exported to Tinybird (ossPackages) via a ReplacingMergeTree versioned
-  // on last_synced_at — a same-version CDC row can lose to the existing one, so this write
-  // must advance it too, or the correction (including a clear) never reaches downstream
-  // consumers. See updateMavenRepositoryUrls in osspckgs/packages.ts for the same pattern.
-  // clock_timestamp() (not NOW()) — callers invoke this after their own package upsert has
-  // already stamped last_synced_at = NOW() in the same transaction; NOW() is transaction-stable
-  // and would tie with that earlier value, while clock_timestamp() advances per statement.
+  // last_synced_at must strictly advance — clock_timestamp(), not the same-tx NOW() the
+  // caller's upsert already used — or this CDC write loses the ReplacingMergeTree tie.
   const affected = await qx.result(
     `UPDATE packages SET repository_url = $(url), last_synced_at = clock_timestamp()
       WHERE id = $(packageId)::bigint AND repository_url IS DISTINCT FROM $(url)`,

--- a/services/libs/data-access-layer/src/packages/packages.ts
+++ b/services/libs/data-access-layer/src/packages/packages.ts
@@ -322,8 +322,12 @@ export async function setPackageRepositoryUrl(
   packageId: string,
   url: string | null,
 ): Promise<string[]> {
+  // repository_url is exported to Tinybird (ossPackages) via a ReplacingMergeTree versioned
+  // on last_synced_at — a same-version CDC row can lose to the existing one, so this write
+  // must advance it too, or the correction (including a clear) never reaches downstream
+  // consumers. See updateMavenRepositoryUrls in osspckgs/packages.ts for the same pattern.
   const affected = await qx.result(
-    `UPDATE packages SET repository_url = $(url)
+    `UPDATE packages SET repository_url = $(url), last_synced_at = NOW()
       WHERE id = $(packageId)::bigint AND repository_url IS DISTINCT FROM $(url)`,
     { url, packageId },
   )
@@ -350,9 +354,10 @@ export async function updatePackagistVersionAggregates(
   qx: QueryExecutor,
   purl: string,
   agg: PackagistVersionAggregates,
-): Promise<{ id: string; changedFields: string[] } | null> {
-  const row: { id: string; changed_fields: string[] } | undefined = await qx.selectOneOrNone(
-    `WITH old AS (
+): Promise<{ id: string; changedFields: string[]; homepage: string | null } | null> {
+  const row: { id: string; changed_fields: string[]; homepage: string | null } | undefined =
+    await qx.selectOneOrNone(
+      `WITH old AS (
        SELECT versions_count, latest_version, first_release_at, latest_release_at, licenses, homepage, ingestion_source
          FROM packages WHERE purl = $(purl) AND ecosystem = 'packagist'
      ),
@@ -370,7 +375,7 @@ export async function updatePackagistVersionAggregates(
        WHERE purl = $(purl) AND ecosystem = 'packagist'
        RETURNING id, versions_count, latest_version, first_release_at, latest_release_at, licenses, homepage, ingestion_source
      )
-     SELECT ins.id::text AS id,
+     SELECT ins.id::text AS id, ins.homepage,
             array_remove(ARRAY[
               CASE WHEN o.versions_count     IS DISTINCT FROM ins.versions_count     THEN 'packages.versions_count' END,
               CASE WHEN o.latest_version     IS DISTINCT FROM ins.latest_version     THEN 'packages.latest_version' END,
@@ -381,11 +386,11 @@ export async function updatePackagistVersionAggregates(
               CASE WHEN o.ingestion_source   IS DISTINCT FROM ins.ingestion_source   THEN 'packages.ingestion_source' END
             ], NULL) AS changed_fields
        FROM ins LEFT JOIN old o ON true`,
-    { purl, ...agg },
-  )
+      { purl, ...agg },
+    )
 
   if (!row) return null
-  return { id: row.id, changedFields: row.changed_fields }
+  return { id: row.id, changedFields: row.changed_fields, homepage: row.homepage }
 }
 
 export async function getPackagistPackageIdsByNames(

--- a/services/libs/data-access-layer/src/packages/packages.ts
+++ b/services/libs/data-access-layer/src/packages/packages.ts
@@ -326,8 +326,11 @@ export async function setPackageRepositoryUrl(
   // on last_synced_at — a same-version CDC row can lose to the existing one, so this write
   // must advance it too, or the correction (including a clear) never reaches downstream
   // consumers. See updateMavenRepositoryUrls in osspckgs/packages.ts for the same pattern.
+  // clock_timestamp() (not NOW()) — callers invoke this after their own package upsert has
+  // already stamped last_synced_at = NOW() in the same transaction; NOW() is transaction-stable
+  // and would tie with that earlier value, while clock_timestamp() advances per statement.
   const affected = await qx.result(
-    `UPDATE packages SET repository_url = $(url), last_synced_at = NOW()
+    `UPDATE packages SET repository_url = $(url), last_synced_at = clock_timestamp()
       WHERE id = $(packageId)::bigint AND repository_url IS DISTINCT FROM $(url)`,
     { url, packageId },
   )

--- a/services/libs/data-access-layer/src/packages/packages.ts
+++ b/services/libs/data-access-layer/src/packages/packages.ts
@@ -334,6 +334,23 @@ export async function setPackageRepositoryUrl(
   return affected > 0 ? ['packages.repository_url'] : []
 }
 
+export async function setPackageDeclaredRepositoryUrl(
+  qx: QueryExecutor,
+  packageId: string,
+  url: string | null,
+): Promise<string[]> {
+  // clock_timestamp() alone can tie last_synced_at at DateTime64(3) resolution — GREATEST
+  // with +1ms over the stored value guarantees a strictly newer CDC version regardless.
+  const affected = await qx.result(
+    `UPDATE packages
+        SET declared_repository_url = $(url),
+            last_synced_at = GREATEST(clock_timestamp(), last_synced_at + interval '1 millisecond')
+      WHERE id = $(packageId)::bigint AND declared_repository_url IS DISTINCT FROM $(url)`,
+    { url, packageId },
+  )
+  return affected > 0 ? ['packages.declared_repository_url'] : []
+}
+
 export async function getPackageHomepage(qx: QueryExecutor, purl: string): Promise<string | null> {
   const row = await qx.selectOneOrNone(`SELECT homepage FROM packages WHERE purl = $(purl)`, {
     purl,

--- a/services/libs/data-access-layer/src/packages/packages.ts
+++ b/services/libs/data-access-layer/src/packages/packages.ts
@@ -273,13 +273,11 @@ export async function updatePackagistPackageStats(
 ): Promise<{
   id: string
   isCritical: boolean
-  homepage: string | null
   changedFields: string[]
 } | null> {
-  const row:
-    | { id: string; is_critical: boolean; homepage: string | null; changed_fields: string[] }
-    | undefined = await qx.selectOneOrNone(
-    `WITH old AS (
+  const row: { id: string; is_critical: boolean; changed_fields: string[] } | undefined =
+    await qx.selectOneOrNone(
+      `WITH old AS (
          SELECT description, declared_repository_url, repository_url, status,
                 total_downloads, dependent_count, ingestion_source
            FROM packages WHERE purl = $(purl) AND ecosystem = 'packagist'
@@ -294,10 +292,10 @@ export async function updatePackagistPackageStats(
            dependent_count           = COALESCE($(dependentCount), dependent_count),
            last_synced_at            = NOW()
          WHERE purl = $(purl) AND ecosystem = 'packagist'
-         RETURNING id, is_critical, homepage, description, declared_repository_url, repository_url,
+         RETURNING id, is_critical, description, declared_repository_url, repository_url,
                    status, total_downloads, dependent_count, ingestion_source
        )
-       SELECT ins.id::text AS id, ins.is_critical, ins.homepage,
+       SELECT ins.id::text AS id, ins.is_critical,
               array_remove(ARRAY[
                 CASE WHEN o.description               IS DISTINCT FROM ins.description               THEN 'packages.description' END,
                 CASE WHEN o.declared_repository_url   IS DISTINCT FROM ins.declared_repository_url   THEN 'packages.declared_repository_url' END,
@@ -308,14 +306,13 @@ export async function updatePackagistPackageStats(
                 CASE WHEN o.ingestion_source          IS DISTINCT FROM ins.ingestion_source          THEN 'packages.ingestion_source' END
               ], NULL) AS changed_fields
          FROM ins LEFT JOIN old o ON true`,
-    input,
-  )
+      input,
+    )
 
   if (!row) return null
   return {
     id: row.id,
     isCritical: row.is_critical,
-    homepage: row.homepage,
     changedFields: row.changed_fields,
   }
 }
@@ -323,7 +320,7 @@ export async function updatePackagistPackageStats(
 export async function setPackageRepositoryUrl(
   qx: QueryExecutor,
   packageId: string,
-  url: string,
+  url: string | null,
 ): Promise<string[]> {
   const affected = await qx.result(
     `UPDATE packages SET repository_url = $(url)
@@ -331,6 +328,13 @@ export async function setPackageRepositoryUrl(
     { url, packageId },
   )
   return affected > 0 ? ['packages.repository_url'] : []
+}
+
+export async function getPackageHomepage(qx: QueryExecutor, purl: string): Promise<string | null> {
+  const row = await qx.selectOneOrNone(`SELECT homepage FROM packages WHERE purl = $(purl)`, {
+    purl,
+  })
+  return row?.homepage ?? null
 }
 
 export interface PackagistVersionAggregates {

--- a/services/libs/data-access-layer/src/packages/repoConfidence.test.ts
+++ b/services/libs/data-access-layer/src/packages/repoConfidence.test.ts
@@ -24,9 +24,10 @@ describe('packageRepoConfidenceLabel', () => {
 })
 
 describe('packageRepoLinkClaimParams', () => {
-  it('defaults provenance for sources that carry none', () => {
+  it('defaults provenance and signal for claims that carry neither', () => {
     expect(packageRepoLinkClaimParams({ source: 'declared' })).toEqual({
       source: 'declared',
+      signal: 'primary',
       provenance: null,
     })
   })
@@ -35,10 +36,12 @@ describe('packageRepoLinkClaimParams', () => {
     expect(
       packageRepoLinkClaimParams({
         source: 'deps_dev',
+        signal: 'secondary',
         provenance: 'SLSA_ATTESTATION',
       }),
     ).toEqual({
       source: 'deps_dev',
+      signal: 'secondary',
       provenance: 'SLSA_ATTESTATION',
     })
   })
@@ -48,6 +51,7 @@ describe('packageRepoConfidenceCall', () => {
   it('binds a new claim to parameters by default', () => {
     const sql = packageRepoConfidenceCall('p', 'r')
     expect(sql).toContain('$(source)')
+    expect(sql).toContain('$(signal)')
     expect(sql).toContain('$(provenance)')
     expect(sql).toContain('p.ecosystem')
     expect(sql).toContain('r.archived')
@@ -56,9 +60,11 @@ describe('packageRepoConfidenceCall', () => {
   it('reads a rescored claim off the stored row', () => {
     const sql = packageRepoConfidenceCall('p', 'r', {
       source: 'pr.source',
+      signal: 'pr.signal',
       provenance: 'pr.provenance',
     })
     expect(sql).not.toContain('$(')
+    expect(sql).toContain('pr.signal')
     expect(sql).toContain('pr.provenance')
   })
 })

--- a/services/libs/data-access-layer/src/packages/repoConfidence.ts
+++ b/services/libs/data-access-layer/src/packages/repoConfidence.ts
@@ -1,4 +1,5 @@
 export type PackageRepoSource = 'declared' | 'deps_dev' | 'heuristic' | 'manual'
+export type PackageRepoSignal = 'primary' | 'secondary'
 export type PackageRepoConfidenceLabel = 'high' | 'medium' | 'low'
 
 export const CONFIDENCE_HIGH_THRESHOLD = 0.8
@@ -12,15 +13,18 @@ export function packageRepoConfidenceLabel(confidence: number): PackageRepoConfi
 
 export type PackageRepoLinkClaim = {
   source: PackageRepoSource
+  signal?: PackageRepoSignal
   provenance?: string | null
 }
 
 export function packageRepoLinkClaimParams(claim: PackageRepoLinkClaim): {
   source: PackageRepoSource
+  signal: PackageRepoSignal
   provenance: string | null
 } {
   return {
     source: claim.source,
+    signal: claim.signal ?? 'primary',
     provenance: claim.provenance ?? null,
   }
 }
@@ -40,6 +44,7 @@ export function competingGithubRepoExpr(packageIdExpr: string, repoIdExpr: strin
 
 export type PackageRepoClaimExprs = {
   source: string
+  signal: string
   provenance: string
 }
 
@@ -47,12 +52,14 @@ export type PackageRepoClaimExprs = {
 // back off the stored row instead.
 export const CLAIM_FROM_PARAMS: PackageRepoClaimExprs = {
   source: '$(source)',
+  signal: '$(signal)',
   provenance: '$(provenance)',
 }
 
 export function claimFromRow(alias: string): PackageRepoClaimExprs {
   return {
     source: `${alias}.source`,
+    signal: `${alias}.signal`,
     provenance: `${alias}.provenance`,
   }
 }
@@ -61,6 +68,9 @@ export function claimFromRow(alias: string): PackageRepoClaimExprs {
 // own row and always replaces, downgrades included (ADR-0020).
 export const KEEP_HIGHEST_CONFLICT_UPDATE = `source           = CASE WHEN EXCLUDED.confidence > package_repos.confidence
                                  THEN EXCLUDED.source ELSE package_repos.source END,
+         signal           = CASE WHEN EXCLUDED.source = package_repos.source
+                                   OR EXCLUDED.confidence > package_repos.confidence
+                                 THEN EXCLUDED.signal ELSE package_repos.signal END,
          provenance       = CASE WHEN EXCLUDED.source = package_repos.source
                                    OR EXCLUDED.confidence > package_repos.confidence
                                  THEN EXCLUDED.provenance ELSE package_repos.provenance END,
@@ -69,7 +79,7 @@ export const KEEP_HIGHEST_CONFLICT_UPDATE = `source           = CASE WHEN EXCLUD
                                  ELSE GREATEST(EXCLUDED.confidence, package_repos.confidence) END,
          verified_at      = NOW()`
 
-// The only path that may produce a package_repos confidence value (V1788307200). The caller
+// The only path that may produce a package_repos confidence value (V1788307300). The caller
 // must have the package and repo rows joined — ecosystem and repo state are read off them.
 export function packageRepoConfidenceCall(
   packageAlias: string,
@@ -80,7 +90,7 @@ export function packageRepoConfidenceCall(
   const competing =
     competingGithubExpr ?? competingGithubRepoExpr(`${packageAlias}.id`, `${repoAlias}.id`)
   return `package_repo_confidence(
-        ${claim.source}, ${packageAlias}.ecosystem, ${claim.provenance},
+        ${claim.source}, ${packageAlias}.ecosystem, ${claim.signal}, ${claim.provenance},
         ${repoAlias}.archived, ${repoAlias}.is_fork, ${repoAlias}.disabled, ${repoAlias}.host,
         ${competing},
         ${repoAlias}.id

--- a/services/libs/data-access-layer/src/packages/repoConfidenceScoring.integration.test.ts
+++ b/services/libs/data-access-layer/src/packages/repoConfidenceScoring.integration.test.ts
@@ -5,7 +5,7 @@ import { getDbConnection } from '@crowd/database'
 import type { QueryExecutor } from '../queryExecutor'
 import { pgpQx } from '../queryExecutor'
 
-// Integration test: hits the running packages-db, where V1788307200 defines
+// Integration test: hits the running packages-db, where V1788307300 defines
 // package_repo_confidence. Skipped when the DB env vars are missing so unit-test runs
 // in CI stay green.
 const HAVE_DB =

--- a/services/libs/data-access-layer/src/packages/repoConfidenceScoring.integration.test.ts
+++ b/services/libs/data-access-layer/src/packages/repoConfidenceScoring.integration.test.ts
@@ -18,6 +18,7 @@ const HAVE_DB =
 type ScoreInput = {
   source: string
   ecosystem?: string
+  signal?: string
   provenance?: string | null
   archived?: boolean | null
   isFork?: boolean | null
@@ -44,11 +45,12 @@ describe.skipIf(!HAVE_DB)('package_repo_confidence', () => {
   async function score(input: ScoreInput): Promise<number> {
     const row = await qx.selectOne(
       `SELECT package_repo_confidence(
-         $(source), $(ecosystem), $(provenance),
+         $(source), $(ecosystem), $(signal), $(provenance),
          $(archived), $(isFork), $(disabled), $(host), $(competingGithub), $(repoId)
        )::float8 AS score`,
       {
         ecosystem: 'npm',
+        signal: 'primary',
         provenance: null,
         archived: null,
         isFork: null,
@@ -73,6 +75,18 @@ describe.skipIf(!HAVE_DB)('package_repo_confidence', () => {
     expect(await score({ source: 'declared' })).toBeCloseTo(0.85, 2)
     expect(await score({ source: 'declared', ecosystem: 'maven' })).toBeCloseTo(0.8, 2)
     expect(await score({ source: 'heuristic' })).toBeCloseTo(0.3, 2)
+  })
+
+  it('penalises a secondary signal on declared links only', async () => {
+    expect(await score({ source: 'declared', signal: 'secondary' })).toBeCloseTo(0.75, 2)
+    expect(await score({ source: 'declared', ecosystem: 'maven', signal: 'secondary' })).toBeCloseTo(
+      0.7,
+      2,
+    )
+    expect(await score({ source: 'manual', signal: 'secondary' })).toBeCloseTo(0.99, 2)
+    expect(
+      await score({ source: 'deps_dev', provenance: 'GO_ORIGIN', signal: 'secondary' }),
+    ).toBeCloseTo(0.9, 2)
   })
 
   it('stacks repo-state penalties and floors at 0.05', async () => {

--- a/services/libs/data-access-layer/src/packages/repoConfidenceScoring.integration.test.ts
+++ b/services/libs/data-access-layer/src/packages/repoConfidenceScoring.integration.test.ts
@@ -79,10 +79,9 @@ describe.skipIf(!HAVE_DB)('package_repo_confidence', () => {
 
   it('penalises a secondary signal on declared links only', async () => {
     expect(await score({ source: 'declared', signal: 'secondary' })).toBeCloseTo(0.75, 2)
-    expect(await score({ source: 'declared', ecosystem: 'maven', signal: 'secondary' })).toBeCloseTo(
-      0.7,
-      2,
-    )
+    expect(
+      await score({ source: 'declared', ecosystem: 'maven', signal: 'secondary' }),
+    ).toBeCloseTo(0.7, 2)
     expect(await score({ source: 'manual', signal: 'secondary' })).toBeCloseTo(0.99, 2)
     expect(
       await score({ source: 'deps_dev', provenance: 'GO_ORIGIN', signal: 'secondary' }),

--- a/services/libs/data-access-layer/src/packages/repoConfidenceWrites.integration.test.ts
+++ b/services/libs/data-access-layer/src/packages/repoConfidenceWrites.integration.test.ts
@@ -8,7 +8,7 @@ import { pgpQx } from '../queryExecutor'
 
 import { upsertPackageRepo } from './repos'
 
-// Integration test: hits the running packages-db, where V1788307200 defines
+// Integration test: hits the running packages-db, where V1788307300 defines
 // package_repo_confidence and rescore_package_repo_confidence. Skipped when the DB env
 // vars are missing so unit-test runs in CI stay green.
 const HAVE_DB =

--- a/services/libs/data-access-layer/src/packages/repoConfidenceWrites.integration.test.ts
+++ b/services/libs/data-access-layer/src/packages/repoConfidenceWrites.integration.test.ts
@@ -152,7 +152,7 @@ describe.skipIf(!HAVE_DB)('package_repos write and rescore policy', () => {
       const link = await storedLink(githubRepoId)
       const expected: { confidence: number } = await qx.selectOne(
         `SELECT package_repo_confidence(
-           pr.source, p.ecosystem, pr.provenance,
+           pr.source, p.ecosystem, pr.signal, pr.provenance,
            r.archived, r.is_fork, r.disabled, r.host, false, pr.repo_id
          )::float8 AS confidence
            FROM package_repos pr

--- a/services/libs/data-access-layer/src/packages/repoConfidenceWrites.integration.test.ts
+++ b/services/libs/data-access-layer/src/packages/repoConfidenceWrites.integration.test.ts
@@ -22,6 +22,7 @@ const FIXTURE = `cm1306-writes-${process.pid}`
 
 type StoredLink = {
   source: string
+  signal: string
   provenance: string | null
   confidence: number
 }
@@ -34,7 +35,7 @@ describe.skipIf(!HAVE_DB)('package_repos write and rescore policy', () => {
 
   async function storedLink(repoId: string): Promise<StoredLink> {
     return qx.selectOne(
-      `SELECT source, provenance, confidence::float8 AS confidence
+      `SELECT source, signal, provenance, confidence::float8 AS confidence
          FROM package_repos
         WHERE package_id = $(packageId)::bigint AND repo_id = $(repoId)::bigint`,
       { packageId, repoId },
@@ -143,6 +144,38 @@ describe.skipIf(!HAVE_DB)('package_repos write and rescore policy', () => {
       const link = await storedLink(githubRepoId)
       expect(link.provenance).toBe('UNVERIFIED_METADATA')
       expect(link.confidence).toBeCloseTo(0.5, 2)
+    })
+
+    it('downgrades the stored signal when the same source restates a weaker signal', async () => {
+      await upsertPackageRepo(qx, packageId, githubRepoId, {
+        source: 'declared',
+        signal: 'primary',
+      })
+      const before = await storedLink(githubRepoId)
+
+      await upsertPackageRepo(qx, packageId, githubRepoId, {
+        source: 'declared',
+        signal: 'secondary',
+      })
+
+      const after = await storedLink(githubRepoId)
+      expect(after.signal).toBe('secondary')
+      expect(before.confidence - after.confidence).toBeCloseTo(0.1, 2)
+    })
+
+    it('keeps the winning signal when a weaker source claims the same link', async () => {
+      await upsertPackageRepo(qx, packageId, githubRepoId, {
+        source: 'declared',
+        signal: 'primary',
+      })
+      await upsertPackageRepo(qx, packageId, githubRepoId, {
+        source: 'heuristic',
+        signal: 'secondary',
+      })
+
+      const link = await storedLink(githubRepoId)
+      expect(link.source).toBe('declared')
+      expect(link.signal).toBe('primary')
     })
 
     it('leaves the stored confidence consistent with the stored source', async () => {

--- a/services/libs/data-access-layer/src/packages/repos.ts
+++ b/services/libs/data-access-layer/src/packages/repos.ts
@@ -140,7 +140,8 @@ function rescoreQuery(targetPredicate: string): string {
           FOR UPDATE
      )
      UPDATE package_repos pr
-        SET confidence = s.confidence, verified_at = NOW()
+        SET confidence = s.confidence,
+            verified_at = GREATEST(clock_timestamp(), pr.verified_at + interval '1 millisecond')
        FROM target t
        JOIN package_repos cur ON cur.id = t.id
        JOIN packages p ON p.id = cur.package_id

--- a/services/libs/data-access-layer/src/packages/repos.ts
+++ b/services/libs/data-access-layer/src/packages/repos.ts
@@ -100,9 +100,9 @@ export async function upsertPackageRepo(
      ),
      ins AS (
        INSERT INTO package_repos (
-         package_id, repo_id, source, provenance, confidence, created_at
+         package_id, repo_id, source, signal, provenance, confidence, created_at
        )
-       SELECT $(packageId)::bigint, $(repoId)::bigint, $(source), $(provenance),
+       SELECT $(packageId)::bigint, $(repoId)::bigint, $(source), $(signal), $(provenance),
               scored.confidence, NOW()
          FROM scored
        ON CONFLICT (package_id, repo_id) DO UPDATE SET

--- a/services/libs/data-access-layer/src/packages/repos.ts
+++ b/services/libs/data-access-layer/src/packages/repos.ts
@@ -90,7 +90,7 @@ export async function upsertPackageRepo(
 
   const row: { changed_fields: string[] } | null = await qx.selectOneOrNone(
     `WITH old AS (
-       SELECT source, confidence FROM package_repos
+       SELECT source, signal, confidence FROM package_repos
         WHERE package_id = $(packageId)::bigint AND repo_id = $(repoId)::bigint
      ),
      scored AS (
@@ -107,12 +107,14 @@ export async function upsertPackageRepo(
          FROM scored
        ON CONFLICT (package_id, repo_id) DO UPDATE SET
          ${KEEP_HIGHEST_CONFLICT_UPDATE}
-       RETURNING source, confidence
+       RETURNING source, signal, confidence
      )
      SELECT array_remove(ARRAY[
        CASE WHEN o.source IS NULL                                         THEN 'package_repos.repo_id' END,
        CASE WHEN o.source IS NULL
               OR o.source           IS DISTINCT FROM ins.source           THEN 'package_repos.source' END,
+       CASE WHEN o.source IS NULL
+              OR o.signal           IS DISTINCT FROM ins.signal           THEN 'package_repos.signal' END,
        CASE WHEN o.source IS NULL
               OR o.confidence IS DISTINCT FROM ins.confidence THEN 'package_repos.confidence' END
      ], NULL) AS changed_fields

--- a/services/libs/tinybird/datasources/packageRepos.datasource
+++ b/services/libs/tinybird/datasources/packageRepos.datasource
@@ -6,6 +6,7 @@ DESCRIPTION >
     - `packageId` links to the parent packages row.
     - `repoId` links to the associated repos row.
     - `source` identifies how the link was established: 'declared', 'deps_dev', 'heuristic', or 'manual'.
+    - `signal` is 'primary' or 'secondary' — whether a 'declared' link came from the ecosystem's dedicated repository field or a lower-trust fallback (homepage/bug tracker).
     - `confidence` is a 0–1 score produced by the package_repo_confidence() function in packages-db, with nine decimal places; the low-order digits are a per-row uniqueness offset, not precision.
     - `provenance` is the deps.dev RelationProvenance for source='deps_dev' rows and empty for every other source.
     - `verifiedAt` is when the link was last confirmed or upserted — serves as the updated_at watermark for sync.
@@ -16,6 +17,7 @@ SCHEMA >
     `packageId` UInt64 `json:$.record.package_id`,
     `repoId` UInt64 `json:$.record.repo_id`,
     `source` String `json:$.record.source`,
+    `signal` String `json:$.record.signal` DEFAULT 'primary',
     `confidence` String `json:$.record.confidence`,
     `provenance` String `json:$.record.provenance` DEFAULT '',
     `verifiedAt` DateTime64(3) `json:$.record.verified_at`,


### PR DESCRIPTION
## What

Packages only ever got a `package_repos` row when the ecosystem's canonical
repository field parsed — npm `repository`, cargo `repository`, rubygems
`source_code_uri`, NuGet `<repository>`, POM `<scm><url>`. A large share of
packages leave that field empty while publishing the same repo URL in
`homepage`, `bugs.url`, `projectUrl`, `bug_tracker_uri`, or POM `<url>`, so
those packages ended up with no repo link at all — invisible to criticality,
blast radius, and Insights.

This adds a `signal` dimension to the link: the canonical field resolves as
`primary`, a fallback field as `secondary`, and a secondary link scores lower
than a declared primary one instead of ranking equally with it.

## Changes

- **Migration `V1788307300__package_repo_signal.sql`** — adds
  `package_repos.signal text NOT NULL DEFAULT 'primary'` (CHECK
  `primary|secondary`), adds a 10-arg `package_repo_confidence()` overload
  taking `p_signal`, and re-creates `rescore_package_repo_confidence` to pass
  `signal` through. The pre-signal 9-arg signature is kept as a compat overload
  that delegates to the 10-arg version as `'primary'`, so callers still on the
  old signature during a rolling deploy keep working; it's dropped in a later
  cleanup migration.
- **−0.10 penalty for `signal = 'secondary'`, on `declared` links only.**
  deps.dev provenance already proves the publisher→repo relationship
  independently of which manifest field carried the URL, and `manual` links are
  operator-pinned. Declared 0.85 → 0.75, maven declared 0.80 → 0.70.
- **Shared helper `packages_worker/src/utils/resolveManifestRepo.ts`** — takes an
  ordered candidate list, returns `{ repo, signal }`. First candidate is the
  ecosystem's canonical field (`primary`), every later one is `secondary`. A
  `secondary` candidate is rejected when canonicalization yields
  `host === 'other'` (recognized VCS hosts only); `primary` keeps its historical
  permissive behaviour so existing self-hosted Gitea/cgit/SVN links are
  unaffected. No writer computes a confidence value.
- **Wired into every registry writer**: npm, pypi, cargo, rubygems, packagist,
  nuget, maven. Cargo is set-based SQL over a dump, so it stages both
  `declared_repository_url` and `homepage` into `repo_norm` and applies the same
  first-wins-with-host-gate rule via a new `repo_choice` table.
- **`setPackageRepositoryUrl`** in the DAL — when a link resolves from a
  fallback field, `packages.repository_url` is backfilled with the resolved URL.
- **Keep-highest conflict policy** (ADR-0020) carries `signal` alongside
  `source`/`provenance`: cross-source keep-highest, same-source always replaces.
- **ADR-0021** documents the decision, the per-ecosystem chains, and the host
  gate.

`ownership_match` is deliberately out of scope here — it lands in CM-1394.

## Notes for review

- The DAL confidence integration tests (`repoConfidenceScoring`,
  `repoConfidenceWrites`) cover the new column, the 10-arg function, the −0.10
  penalty and the rescore path, but they're `describe.skipIf(!HAVE_DB)` and were
  not run locally — they need `CROWD_PACKAGES_DB_*` set and
  `V1788307300` applied. Worth running against a real packages-db before merge.
- `cargo/`, `nuget/`, `rubygems/` and `deps-dev/` have no unit test files at
  all; their changes here are covered only by the shared
  `resolveManifestRepo` tests plus review.

