### PR TITLE
feat: connect criticality score discovery source with per-source new-project cap (CM-1423)

### DIFF
--- a/services/apps/automatic_projects_discovery_worker/README.md
+++ b/services/apps/automatic_projects_discovery_worker/README.md
@@ -43,10 +43,16 @@ discoverProjects({ mode: 'incremental' | 'full' })
 ```
 
 Each source is capped independently at `CROWD_DISCOVERY_NEW_PROJECTS_LIMIT` (default 20) _new_
-projects per run — rows already present in `projectCatalog` don't count against the cap and
-aren't re-fetched, so every run brings in genuinely new candidates. Sources are processed in
-registry order (`insights-discussions`, then `lf-criticality-score`); once a source hits its
-limit, `processDataset` stops consuming its stream early.
+projects per `processDataset` call — rows already present in `projectCatalog` are still fetched
+from the source but don't count against the cap, so every run brings in genuinely new candidates.
+Sources are processed in registry order (`insights-discussions`, then `lf-criticality-score`);
+once a source hits its limit, `processDataset` stops consuming its stream early.
+
+In `full` mode the cap applies per dataset, not per source: a source with N historical dataset
+snapshots can add up to `N × CROWD_DISCOVERY_NEW_PROJECTS_LIMIT` new rows in a single `full` run,
+since each dataset is processed by its own `processDataset` call. This is intentional for an
+initial backfill; `incremental` (the daily schedule) only ever processes the latest dataset, so
+the cap is a true per-source-per-run limit there.
 
 ### Timeouts
 

--- a/services/apps/automatic_projects_discovery_worker/README.md
+++ b/services/apps/automatic_projects_discovery_worker/README.md
@@ -21,10 +21,10 @@ source names) restricts which ones run; unset enables all of them.
 
 ### Current sources
 
-| Name                  | Folder                             | Description                                                                        |
-| --------------------- | ----------------------------------- | ----------------------------------------------------------------------------------- |
+| Name                   | Folder                              | Description                                                                                           |
+| ---------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | `insights-discussions` | `src/sources/insights-discussions/` | Repo URLs mentioned in `linuxfoundation/insights` GitHub Discussions (`project-onboardings` category) |
-| `lf-criticality-score` | `src/sources/lf-criticality-score/` | LF Criticality Score API, paginated, ordered by score descending                    |
+| `lf-criticality-score` | `src/sources/lf-criticality-score/` | LF Criticality Score API, paginated, ordered by score descending                                      |
 
 ### Workflow
 
@@ -42,7 +42,7 @@ discoverProjects({ mode: 'incremental' | 'full' })
             whose repoUrl isn't already in projectCatalog → bulkInsertProjectCatalog
 ```
 
-Each source is capped independently at `CROWD_DISCOVERY_NEW_PROJECTS_LIMIT` (default 20) *new*
+Each source is capped independently at `CROWD_DISCOVERY_NEW_PROJECTS_LIMIT` (default 20) _new_
 projects per run — rows already present in `projectCatalog` don't count against the cap and
 aren't re-fetched, so every run brings in genuinely new candidates. Sources are processed in
 registry order (`insights-discussions`, then `lf-criticality-score`); once a source hits its
@@ -50,11 +50,11 @@ limit, `processDataset` stops consuming its stream early.
 
 ### Timeouts
 
-| Activity            | startToCloseTimeout | retries | notes                                  |
-| -------------------- | -------------------- | ------- | --------------------------------------- |
-| `listDatasets`        | 2 min                 | 3       |                                          |
-| `processDataset`      | 90 min                | 3       | heartbeat every 5 min                   |
-| Workflow execution    | 5 hours               | 3       | set on the schedule                     |
+| Activity           | startToCloseTimeout | retries | notes                 |
+| ------------------ | ------------------- | ------- | --------------------- |
+| `listDatasets`     | 2 min               | 3       |                       |
+| `processDataset`   | 90 min              | 3       | heartbeat every 5 min |
+| Workflow execution | 5 hours             | 3       | set on the schedule   |
 
 ### Schedule
 

--- a/services/apps/automatic_projects_discovery_worker/README.md
+++ b/services/apps/automatic_projects_discovery_worker/README.md
@@ -14,15 +14,17 @@ Every data source implements the `IDiscoverySource` interface (`src/sources/type
 | `fetchDatasetStream(dataset)` | Returns a readable stream for the dataset (e.g. HTTP response)              |
 | `parseRow(rawRow)`            | Converts a raw CSV/JSON row into a `IDiscoverySourceRow`, or `null` to skip |
 
-Sources are registered in `src/sources/registry.ts` as a simple name → factory map.
+Sources are registered in `src/sources/registry.ts`. `CROWD_DISCOVERY_SOURCES` (comma-separated
+source names) restricts which ones run; unset enables all of them.
 
 **To add a new source:** create a class implementing `IDiscoverySource`, then add one line to the registry.
 
 ### Current sources
 
-| Name                     | Folder                                | Description                                                                          |
-| ------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------ |
-| `ossf-criticality-score` | `src/sources/ossf-criticality-score/` | OSSF Criticality Score snapshots from a public GCS bucket (~750K repos per snapshot) |
+| Name                  | Folder                             | Description                                                                        |
+| --------------------- | ----------------------------------- | ----------------------------------------------------------------------------------- |
+| `insights-discussions` | `src/sources/insights-discussions/` | Repo URLs mentioned in `linuxfoundation/insights` GitHub Discussions (`project-onboardings` category) |
+| `lf-criticality-score` | `src/sources/lf-criticality-score/` | LF Criticality Score API, paginated, ordered by score descending                    |
 
 ### Workflow
 
@@ -36,16 +38,23 @@ discoverProjects({ mode: 'incremental' | 'full' })
   │
   └─ For each dataset:
       └─ Activity: processDataset(sourceName, dataset)
-          → HTTP stream → csv-parse → batches of 5000 → bulkUpsertProjectCatalog
+          → stream rows → parseRow → keep up to DISCOVERY_NEW_PROJECTS_LIMIT rows
+            whose repoUrl isn't already in projectCatalog → bulkInsertProjectCatalog
 ```
+
+Each source is capped independently at `CROWD_DISCOVERY_NEW_PROJECTS_LIMIT` (default 20) *new*
+projects per run — rows already present in `projectCatalog` don't count against the cap and
+aren't re-fetched, so every run brings in genuinely new candidates. Sources are processed in
+registry order (`insights-discussions`, then `lf-criticality-score`); once a source hits its
+limit, `processDataset` stops consuming its stream early.
 
 ### Timeouts
 
-| Activity           | startToCloseTimeout | retries |
-| ------------------ | ------------------- | ------- |
-| `listDatasets`     | 2 min               | 3       |
-| `processDataset`   | 30 min              | 3       |
-| Workflow execution | 2 hours             | 3       |
+| Activity            | startToCloseTimeout | retries | notes                                  |
+| -------------------- | -------------------- | ------- | --------------------------------------- |
+| `listDatasets`        | 2 min                 | 3       |                                          |
+| `processDataset`      | 90 min                | 3       | heartbeat every 5 min                   |
+| Workflow execution    | 5 hours               | 3       | set on the schedule                     |
 
 ### Schedule
 
@@ -56,18 +65,20 @@ Runs daily at midnight via Temporal cron (`0 0 * * *`).
 ```
 src/
 ├── main.ts                          # Service bootstrap (postgres enabled)
+├── config.ts                        # Shared env config (parseEnvInt, DISCOVERY_NEW_PROJECTS_LIMIT)
 ├── activities.ts                    # Barrel re-export
 ├── workflows.ts                     # Barrel re-export
 ├── activities/
-│   └── activities.ts                # listDatasets, processDataset
+│   └── activities.ts                # listSources, listDatasets, processDataset
 ├── workflows/
 │   └── discoverProjects.ts          # Orchestration with mode selection
 ├── schedules/
 │   └── scheduleProjectsDiscovery.ts # Temporal cron schedule
 └── sources/
     ├── types.ts                     # IDiscoverySource, IDatasetDescriptor
-    ├── registry.ts                  # Source factory map
-    └── ossf-criticality-score/
-        ├── source.ts                # IDiscoverySource implementation
-        └── bucketClient.ts          # GCS public bucket HTTP client
+    ├── registry.ts                  # Source list + CROWD_DISCOVERY_SOURCES gate
+    ├── insights-discussions/
+    │   └── source.ts                # IDiscoverySource implementation
+    └── lf-criticality-score/
+        └── source.ts                # IDiscoverySource implementation
 ```

--- a/services/apps/automatic_projects_discovery_worker/src/activities/activities.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/activities/activities.ts
@@ -16,9 +16,9 @@ import { IDatasetDescriptor } from '../sources/types'
 
 const log = getServiceLogger()
 
-// Candidates are collected in chunks this size before checking which repoUrls
-// already exist in projectCatalog, so we don't do one DB round-trip per row.
-const CANDIDATE_CHUNK_SIZE = 500
+// Matches the LF Criticality Score API's page size, so the stream can stop after one page
+// once a chunk satisfies the cap, instead of always fetching several pages upfront.
+const CANDIDATE_CHUNK_SIZE = 100
 
 export async function listSources(): Promise<string[]> {
   return getAvailableSourceNames()

--- a/services/apps/automatic_projects_discovery_worker/src/activities/activities.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/activities/activities.ts
@@ -1,18 +1,24 @@
 import { Context } from '@temporalio/activity'
 import { parse } from 'csv-parse'
 
-import { bulkUpsertProjectCatalog } from '@crowd/data-access-layer'
+import {
+  bulkInsertProjectCatalog,
+  findExistingProjectCatalogRepoUrls,
+} from '@crowd/data-access-layer'
 import { IDbProjectCatalogCreate } from '@crowd/data-access-layer/src/project-catalog/types'
 import { pgpQx } from '@crowd/data-access-layer/src/queryExecutor'
 import { getServiceLogger } from '@crowd/logging'
 
+import { DISCOVERY_NEW_PROJECTS_LIMIT } from '../config'
 import { svc } from '../main'
 import { getAvailableSourceNames, getSource } from '../sources/registry'
 import { IDatasetDescriptor } from '../sources/types'
 
 const log = getServiceLogger()
 
-const BATCH_SIZE = 5000
+// Candidates are collected in chunks this size before checking which repoUrls
+// already exist in projectCatalog, so we don't do one DB round-trip per row.
+const CANDIDATE_CHUNK_SIZE = 500
 
 export async function listSources(): Promise<string[]> {
   return getAvailableSourceNames()
@@ -72,11 +78,40 @@ export async function processDataset(
     })
   }
 
-  let batch: IDbProjectCatalogCreate[] = []
-  let totalProcessed = 0
-  let totalSkipped = 0
-  let batchNumber = 0
+  const accepted: IDbProjectCatalogCreate[] = []
+  const acceptedRepoUrls = new Set<string>()
+  let chunk: IDbProjectCatalogCreate[] = []
   let totalRows = 0
+  let totalSkipped = 0
+
+  async function acceptNewRows(candidates: IDbProjectCatalogCreate[]): Promise<void> {
+    const seenInChunk = new Set<string>()
+    const unseen = candidates.filter(
+      (c) =>
+        !acceptedRepoUrls.has(c.repoUrl) &&
+        !seenInChunk.has(c.repoUrl) &&
+        seenInChunk.add(c.repoUrl),
+    )
+    if (unseen.length === 0) {
+      return
+    }
+
+    const existingRepoUrls = await findExistingProjectCatalogRepoUrls(
+      qx,
+      unseen.map((c) => c.repoUrl),
+    )
+
+    for (const candidate of unseen) {
+      if (accepted.length >= DISCOVERY_NEW_PROJECTS_LIMIT) {
+        break
+      }
+      if (existingRepoUrls.has(candidate.repoUrl)) {
+        continue
+      }
+      accepted.push(candidate)
+      acceptedRepoUrls.add(candidate.repoUrl)
+    }
+  }
 
   for await (const rawRow of records) {
     totalRows++
@@ -87,7 +122,7 @@ export async function processDataset(
       continue
     }
 
-    batch.push({
+    chunk.push({
       projectSlug: parsed.projectSlug,
       repoName: parsed.repoName,
       repoUrl: parsed.repoUrl,
@@ -96,27 +131,34 @@ export async function processDataset(
       lfCriticalityScore: parsed.lfCriticalityScore,
     })
 
-    if (batch.length >= BATCH_SIZE) {
-      batchNumber++
+    if (chunk.length >= CANDIDATE_CHUNK_SIZE) {
+      await acceptNewRows(chunk)
+      chunk = []
 
-      await bulkUpsertProjectCatalog(qx, batch)
-      totalProcessed += batch.length
-      batch = []
+      Context.current().heartbeat({ totalRows, accepted: accepted.length })
 
-      Context.current().heartbeat({ totalProcessed, batchNumber })
-      log.info({ totalProcessed, batchNumber, datasetId: dataset.id }, 'Batch upserted.')
+      if (accepted.length >= DISCOVERY_NEW_PROJECTS_LIMIT) {
+        log.info(
+          { sourceName, datasetId: dataset.id, totalRows, accepted: accepted.length },
+          'Discovery limit reached, stopping stream.',
+        )
+        break
+      }
     }
   }
 
-  // Flush remaining rows that didn't fill a complete batch
-  if (batch.length > 0) {
-    batchNumber++
-    log.info(
-      { sourceName, datasetId: dataset.id, batchSize: batch.length },
-      'Flushing final batch...',
-    )
-    await bulkUpsertProjectCatalog(qx, batch)
-    totalProcessed += batch.length
+  // Flush a final partial chunk, unless the limit was already hit above.
+  if (chunk.length > 0 && accepted.length < DISCOVERY_NEW_PROJECTS_LIMIT) {
+    await acceptNewRows(chunk)
+  }
+
+  records.destroy()
+  if (stream !== records) {
+    stream.destroy()
+  }
+
+  if (accepted.length > 0) {
+    await bulkInsertProjectCatalog(qx, accepted)
   }
 
   const elapsedSeconds = ((Date.now() - startTime) / 1000).toFixed(1)
@@ -126,9 +168,8 @@ export async function processDataset(
       sourceName,
       datasetId: dataset.id,
       totalRows,
-      totalProcessed,
       totalSkipped,
-      totalBatches: batchNumber,
+      totalAccepted: accepted.length,
       elapsedSeconds,
     },
     'Dataset processing complete.',

--- a/services/apps/automatic_projects_discovery_worker/src/config.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/config.ts
@@ -1,0 +1,17 @@
+export function parseEnvInt(
+  value: string | undefined,
+  defaultValue: number,
+  min: number,
+  max: number,
+): number {
+  const parsed = parseInt(value ?? '', 10)
+  return Number.isFinite(parsed) && parsed >= min && parsed <= max ? parsed : defaultValue
+}
+
+// Max new (not-yet-in-projectCatalog) rows a single source can add per discovery run.
+export const DISCOVERY_NEW_PROJECTS_LIMIT = parseEnvInt(
+  process.env.CROWD_DISCOVERY_NEW_PROJECTS_LIMIT,
+  20,
+  1,
+  10_000,
+)

--- a/services/apps/automatic_projects_discovery_worker/src/config.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/config.ts
@@ -8,7 +8,6 @@ export function parseEnvInt(
   return Number.isFinite(parsed) && parsed >= min && parsed <= max ? parsed : defaultValue
 }
 
-// Max new (not-yet-in-projectCatalog) rows a single source can add per discovery run.
 export const DISCOVERY_NEW_PROJECTS_LIMIT = parseEnvInt(
   process.env.CROWD_DISCOVERY_NEW_PROJECTS_LIMIT,
   20,

--- a/services/apps/automatic_projects_discovery_worker/src/sources/lf-criticality-score/source.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/sources/lf-criticality-score/source.ts
@@ -78,10 +78,14 @@ function parseRetryAfterMs(header: string | string[] | undefined): number | null
   return Number.isFinite(secs) && secs > 0 ? secs * 1000 : null
 }
 
+// Bounds a single request so a hung connection doesn't block the activity's heartbeat
+// for the full Temporal heartbeatTimeout (5 min) while the socket stays open.
+const REQUEST_TIMEOUT_MS = 30_000
+
 function httpGet(url: string): Promise<HttpGetResult> {
   return new Promise((resolve, reject) => {
     const client = url.startsWith('https://') ? https : http
-    const req = client.get(url, (res) => {
+    const req = client.get(url, { timeout: REQUEST_TIMEOUT_MS }, (res) => {
       const statusCode = res.statusCode ?? 0
       const retryAfterMs = parseRetryAfterMs(res.headers['retry-after'])
       const chunks: Uint8Array[] = []
@@ -91,6 +95,9 @@ function httpGet(url: string): Promise<HttpGetResult> {
       )
       res.on('error', reject)
     })
+    req.on('timeout', () =>
+      req.destroy(new Error(`Request timed out after ${REQUEST_TIMEOUT_MS}ms`)),
+    )
     req.on('error', reject)
     req.end()
   })

--- a/services/apps/automatic_projects_discovery_worker/src/sources/lf-criticality-score/source.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/sources/lf-criticality-score/source.ts
@@ -5,23 +5,13 @@ import { Readable } from 'stream'
 import { timeout } from '@crowd/common'
 import { getServiceLogger } from '@crowd/logging'
 
+import { parseEnvInt } from '../../config'
 import { IDatasetDescriptor, IDiscoverySource, IDiscoverySourceRow } from '../types'
 
 const log = getServiceLogger()
 
-const DEFAULT_API_HOST = 'lf-criticality-score-api.example.com'
 const DEFAULT_API_PORT = 443
 const PAGE_SIZE = 100
-
-function parseEnvInt(
-  value: string | undefined,
-  defaultValue: number,
-  min: number,
-  max: number,
-): number {
-  const parsed = parseInt(value ?? '', 10)
-  return Number.isFinite(parsed) && parsed >= min && parsed <= max ? parsed : defaultValue
-}
 
 // Requests per second sent to the LF Criticality Score API (throttle between pages).
 const REQUESTS_PER_SECOND = parseEnvInt(
@@ -64,9 +54,12 @@ function getApiBaseUrl(): string {
   if (process.env.LF_CRITICALITY_SCORE_API_URL) {
     return process.env.LF_CRITICALITY_SCORE_API_URL.replace(/\/$/, '')
   }
-  const host = (process.env.LF_CRITICALITY_SCORE_API_HOST ?? DEFAULT_API_HOST)
-    .trim()
-    .replace(/\/$/, '')
+  const host = process.env.LF_CRITICALITY_SCORE_API_HOST?.trim().replace(/\/$/, '')
+  if (!host) {
+    throw new Error(
+      'LF Criticality Score API host is not configured. Set LF_CRITICALITY_SCORE_API_URL or LF_CRITICALITY_SCORE_API_HOST.',
+    )
+  }
   const port = parseInt(process.env.LF_CRITICALITY_SCORE_API_PORT ?? String(DEFAULT_API_PORT), 10)
   const scheme = port === 443 ? 'https' : 'http'
   return `${scheme}://${host}:${port}`

--- a/services/apps/automatic_projects_discovery_worker/src/sources/registry.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/sources/registry.ts
@@ -1,12 +1,35 @@
 import { InsightsDiscussionsSource } from './insights-discussions/source'
-// import { LfCriticalityScoreSource } from './lf-criticality-score/source'
+import { LfCriticalityScoreSource } from './lf-criticality-score/source'
 import { IDiscoverySource } from './types'
 
-// lf-criticality-score disabled locally: no production deployment yet, will be reintegrated later
-const sources: IDiscoverySource[] = [
-  // new LfCriticalityScoreSource(),
+const allSources: IDiscoverySource[] = [
   new InsightsDiscussionsSource(),
+  new LfCriticalityScoreSource(),
 ]
+
+function resolveEnabledSources(): IDiscoverySource[] {
+  const raw = process.env.CROWD_DISCOVERY_SOURCES
+  if (!raw) {
+    return allSources
+  }
+
+  const requestedNames = raw
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean)
+
+  const knownNames = allSources.map((s) => s.name)
+  const unknownNames = requestedNames.filter((name) => !knownNames.includes(name))
+  if (unknownNames.length > 0) {
+    throw new Error(
+      `Unknown source(s) in CROWD_DISCOVERY_SOURCES: ${unknownNames.join(', ')}. Available: ${knownNames.join(', ')}`,
+    )
+  }
+
+  return allSources.filter((s) => requestedNames.includes(s.name))
+}
+
+const sources = resolveEnabledSources()
 
 export function getSource(name: string): IDiscoverySource {
   const source = sources.find((s) => s.name === name)

--- a/services/apps/automatic_projects_discovery_worker/src/workflows/discoverProjects.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/workflows/discoverProjects.ts
@@ -31,8 +31,9 @@ export async function discoverProjects(
 
     // allDatasets is sorted newest-first.
     // Incremental: process only the latest snapshot.
-    // Full: process oldest-first so the newest data wins the final upsert.
-    const datasets = mode === 'incremental' ? [allDatasets[0]] : [...allDatasets].reverse()
+    // Full: process newest-first too, since processDataset only inserts repoUrls
+    // not already in projectCatalog — the first dataset to see a repoUrl wins.
+    const datasets = mode === 'incremental' ? [allDatasets[0]] : allDatasets
 
     log.info(
       `source=${sourceName} mode=${mode}, ${datasets.length}/${allDatasets.length} datasets to process.`,

--- a/services/apps/projects_evaluation_worker/src/schedules/scheduleProjectsEvaluation.ts
+++ b/services/apps/projects_evaluation_worker/src/schedules/scheduleProjectsEvaluation.ts
@@ -10,7 +10,7 @@ const EVALUATION_ARGS: IEvaluateProjectsInput = {
   batchSize: 20,
   priorityConfig: {
     evaluateLimit: 20,
-    sourcePriority: ['manual', 'insights-discussions'],
+    sourcePriority: ['manual', 'insights-discussions', 'lf-criticality-score'],
   },
 }
 

--- a/services/apps/projects_evaluation_worker/src/workflows/evaluateProjects.ts
+++ b/services/apps/projects_evaluation_worker/src/workflows/evaluateProjects.ts
@@ -23,7 +23,7 @@ const evaluateActivities = proxyActivities<typeof activities>({
 
 const DEFAULT_PRIORITY_CONFIG: IPriorityConfig = {
   evaluateLimit: 50,
-  sourcePriority: ['manual', 'insights-discussions'],
+  sourcePriority: ['manual', 'insights-discussions', 'lf-criticality-score'],
 }
 
 export async function evaluateProjects(input: IEvaluateProjectsInput = {}): Promise<void> {

--- a/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
+++ b/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
@@ -132,6 +132,26 @@ export async function findProjectCatalogPendingOnboarding(
   )
 }
 
+export async function findExistingProjectCatalogRepoUrls(
+  qx: QueryExecutor,
+  repoUrls: string[],
+): Promise<Set<string>> {
+  if (repoUrls.length === 0) {
+    return new Set()
+  }
+
+  const rows: { repoUrl: string }[] = await qx.select(
+    `
+    SELECT "repoUrl"
+    FROM "projectCatalog"
+    WHERE "repoUrl" = ANY($(repoUrls)::text[])
+    `,
+    { repoUrls },
+  )
+
+  return new Set(rows.map((row) => row.repoUrl))
+}
+
 export async function countProjectCatalog(qx: QueryExecutor): Promise<number> {
   const result = await qx.selectOne(
     `
@@ -413,71 +433,6 @@ export async function upsertProjectCatalogManualAction(
     RETURNING ${prepareSelectColumns(PROJECT_CATALOG_COLUMNS)}
     `,
     data,
-  )
-}
-
-export async function bulkUpsertProjectCatalog(
-  qx: QueryExecutor,
-  items: IDbProjectCatalogCreate[],
-): Promise<void> {
-  if (items.length === 0) {
-    return
-  }
-
-  const values = items.map((item) => ({
-    projectSlug: item.projectSlug,
-    repoName: item.repoName,
-    repoUrl: item.repoUrl,
-    source: item.source ?? null,
-    action: item.action ?? 'auto',
-    lfCriticalityScore: item.lfCriticalityScore ?? null,
-  }))
-
-  await qx.result(
-    `
-    INSERT INTO "projectCatalog" (
-      "projectSlug",
-      "repoName",
-      "repoUrl",
-      "source",
-      "action",
-      "lfCriticalityScore",
-      "createdAt",
-      "updatedAt",
-      "syncedAt"
-    )
-    SELECT
-      v."projectSlug",
-      v."repoName",
-      v."repoUrl",
-      v."source",
-      v."action",
-      v."lfCriticalityScore"::double precision,
-      NOW(),
-      NOW(),
-      NOW()
-    FROM jsonb_to_recordset($(values)::jsonb) AS v(
-      "projectSlug" text,
-      "repoName" text,
-      "repoUrl" text,
-      "source" text,
-      "action" text,
-      "lfCriticalityScore" double precision
-    )
-    ON CONFLICT ("repoUrl") DO UPDATE SET
-      "projectSlug" = EXCLUDED."projectSlug",
-      "repoName" = EXCLUDED."repoName",
-      "source" = COALESCE(EXCLUDED."source", "projectCatalog"."source"),
-      "action" = CASE
-        WHEN "projectCatalog"."action" IN ('onboard', 'onboarded', 'skip', 'unsure', 'error') THEN "projectCatalog"."action"
-        WHEN EXCLUDED.action = 'evaluate' THEN 'evaluate'
-        ELSE "projectCatalog"."action"
-      END,
-      "lfCriticalityScore" = COALESCE(EXCLUDED."lfCriticalityScore", "projectCatalog"."lfCriticalityScore"),
-      "updatedAt" = NOW(),
-      "syncedAt" = NOW()
-    `,
-    { values: JSON.stringify(values) },
   )
 }
 


### PR DESCRIPTION
## Summary

`LfCriticalityScoreSource` was fully implemented but commented out of the discovery
registry — the LF Criticality Score API had no production deployment, so mass discovery
of critical projects never happened. This PR (CM-1423) re-enables the source and, per an
additional ask, bounds and freshens the intake: today `processDataset` upserts everything
a source returns (~750K rows for criticality-score); instead each run now takes at most
**N new** projects **per source**, skipping any `repoUrl` already in `projectCatalog`.

## Changes

- **Re-enable `lf-criticality-score`** (`sources/registry.ts`) behind a new
  `CROWD_DISCOVERY_SOURCES` env gate (comma-separated allowlist; unset = all sources
  enabled; unknown name throws at load time). Registry order stays
  `insights-discussions` → `lf-criticality-score`.
- **Fail fast on missing config** (`sources/lf-criticality-score/source.ts`) — dropped the
  `lf-criticality-score-api.example.com` placeholder host. `getApiBaseUrl()` now throws
  immediately if neither `LF_CRITICALITY_SCORE_API_URL` nor `LF_CRITICALITY_SCORE_API_HOST`
  is set, instead of burning `MAX_ATTEMPTS` (7) exponential backoffs against a fake host.
- **New shared config module** (`src/config.ts`) — `parseEnvInt` moved out of the
  criticality-score source (was private there) and a new shared
  `DISCOVERY_NEW_PROJECTS_LIMIT` (`CROWD_DISCOVERY_NEW_PROJECTS_LIMIT`, default 20),
  applied identically to every source.
- **Per-source cap + skip-existing** (`activities/activities.ts`) — replaced the
  "buffer 5000 → `bulkUpsertProjectCatalog`" loop with a bounded collect: rows are
  buffered in 500-row chunks, checked against `projectCatalog` via the new
  `findExistingProjectCatalogRepoUrls` DAL function, and only genuinely new `repoUrl`s are
  kept, up to the shared cap. The stream is destroyed as soon as the cap is hit — since the
  criticality API returns rows ordered by score descending, this means 1-2 pages fetched
  instead of walking all `totalPages`. Insert now uses `bulkInsertProjectCatalog`
  (`ON CONFLICT DO NOTHING`) instead of `bulkUpsertProjectCatalog`, since we only ever
  write rows just verified as new.
- **New DAL function** (`data-access-layer/project-catalog/projectCatalog.ts`) —
  `findExistingProjectCatalogRepoUrls(qx, repoUrls)`, additive only, hits the existing
  `uix_projectCatalog_repoUrl` index (no migration needed). Removed the now-unused
  `bulkUpsertProjectCatalog`.
- **Explicit promotion priority** — `sourcePriority` in both
  `projects_evaluation_worker/src/workflows/evaluateProjects.ts` and
  `.../schedules/scheduleProjectsEvaluation.ts` now lists `lf-criticality-score`
  explicitly (behaviourally identical — unlisted sources already ranked last — but
  documents intent). `evaluateLimit` unchanged at 20.
- **README refresh** for the discovery worker: sources table, workflow diagram
  (per-source cap + skip-existing), file tree.

**Trade-off accepted:** discovery no longer refreshes `lfCriticalityScore` / `syncedAt` on
rows already in the catalog, since it now skips anything already present. Scores are read
at promotion time from whatever was stored on first discovery. Worth a follow-up if score
freshness turns out to matter for ranking.

**Note on `services/libs/data-access-layer`:** this PR touches a protected/shared path
(additive DAL function + removal of an unused one) — flagging for code owner review.


