### PR TITLE
fix: throw conflict when resolve matches a different LFID (CM-1424)

### DIFF
--- a/backend/src/api/public/openapi.yaml
+++ b/backend/src/api/public/openapi.yaml
@@ -189,15 +189,26 @@ paths:
                   code: NOT_FOUND
                   message: Member not found
         '409':
-          description: Multiple member profiles matched.
+          description: >
+            Multiple member profiles matched, or the matched member holds a
+            verified LFID that is not among the supplied lfids.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HttpError'
-              example:
-                error:
-                  code: CONFLICT
-                  message: Multiple member profiles matched
+              examples:
+                multipleMembers:
+                  summary: Multiple member profiles matched
+                  value:
+                    error:
+                      code: CONFLICT
+                      message: Multiple member profiles matched
+                foreignLfid:
+                  summary: Matched member holds a different LFID
+                  value:
+                    error:
+                      code: CONFLICT
+                      message: Member holds a different LFID
         '429':
           description: Per-client rate limit exceeded (200 req/min).
           headers:

--- a/backend/src/api/public/v1/members/resolveMember.ts
+++ b/backend/src/api/public/v1/members/resolveMember.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from 'express'
 import { z } from 'zod'
 
 import { ConflictError, NotFoundError } from '@crowd/common'
-import { findMemberIdsByIdentities } from '@crowd/data-access-layer'
+import { fetchMemberIdentities, findMemberIdsByIdentities } from '@crowd/data-access-layer'
 import { IMemberIdentity, MemberIdentityType, PlatformType } from '@crowd/types'
 
 import { optionsQx } from '@/database/sequelizeQueryExecutor'
@@ -42,6 +42,27 @@ export async function resolveMemberByIdentities(req: Request, res: Response): Pr
   }
 
   const memberId = memberIds[0]
+
+  if (emails?.length) {
+    const memberIdentities = await fetchMemberIdentities(qx, memberId)
+    const memberLfids = memberIdentities
+      .filter(
+        (identity) =>
+          identity.verified &&
+          identity.platform === PlatformType.LFID &&
+          identity.type === MemberIdentityType.USERNAME,
+      )
+      .map((identity) => identity.value.toLowerCase())
+
+    const suppliedLfids = new Set(lfids.map((lfid) => lfid.toLowerCase()))
+    const holdsSuppliedLfid = memberLfids.some((lfid) => suppliedLfids.has(lfid))
+
+    // Email can match a member that was never looked up by LFID. If that member
+    // already has a different verified LFID, treat it as a conflict.
+    if (memberLfids.length > 0 && !holdsSuppliedLfid) {
+      throw new ConflictError('Member holds a different LFID')
+    }
+  }
 
   ok(res, { memberId })
 }


### PR DESCRIPTION
## Summary
`POST /v1/members/resolve` ORs LFID and email, so a verified email can return a member that never held the supplied LFID. That member id then gets emitted as Segment `user_id`. After a unique match, if emails were sent and the member has a verified LFID that is not in the request, we now return 409.

## Changes
- In `resolveMember`, after the single-member lookup, load that member's verified LFID identities and throw `Member holds a different LFID` when none of them were supplied
- Document the extra 409 case on the resolve endpoint in OpenAPI