### PR TITLE
feat: add health_score_report_lifecycle Tinybird pipe (IN-1287)

### DIFF
--- a/services/libs/tinybird/pipes/health_score_report_lifecycle.pipe
+++ b/services/libs/tinybird/pipes/health_score_report_lifecycle.pipe
@@ -1,0 +1,33 @@
+DESCRIPTION >
+    - `health_score_report_lifecycle.pipe` serves widget 02 "How projects are maintained" for the
+    Health Score report (IN-1287, part of epic IN-1276 Health Score Coverage).
+    - Returns one row per `lifecycleLabel` value: how many tracked projects fall into each
+    maintenance-lifecycle state, regardless of whether they have a Health Score v2 yet — the
+    denominator is all tracked projects in scope, not just scored ones.
+    - `label` — `lifecycleLabel` value (`active`, `stable`, `declining`, `inert`, `abandoned`,
+    `archived`), or `NULL` when the project has no linked package data to derive a lifecycle state
+    from (rendered by the client as "Unavailable").
+    - `projects` — count of tracked projects (`type = 'project'`) with that lifecycle label.
+    - Parameters:
+    - `scope`: Optional string, default `all`, values `all | lf | other` — filters by `isLF` when
+    `lf`/`other` is given; `all` applies no filter.
+
+TOKEN "insights-app-token" READ
+
+TAGS "Insights, Widget", "Health"
+
+NODE health_score_report_lifecycle_endpoint
+SQL >
+    %
+    SELECT lifecycleLabel AS label, count() AS projects
+    FROM project_insights_copy_ds
+    WHERE
+        type = 'project'
+        {% if String(
+            scope, 'all', description="Scope filter: all | lf | other", required=False
+        ) == 'lf' %} AND isLF = 1
+        {% elif String(
+            scope, 'all', description="Scope filter: all | lf | other", required=False
+        ) == 'other' %} AND isLF = 0
+        {% end %}
+    GROUP BY label


### PR DESCRIPTION
## Summary

Adds the `health_score_report_lifecycle` Tinybird endpoint pipe for widget 02
("How projects are maintained") of the Health Score Coverage report (epic IN-1276).

- Reads the existing `project_insights_copy_ds` datasource — no new datasource, no schema change.
- Returns one row per `lifecycleLabel` value (`active`/`stable`/`declining`/`inert`/`abandoned`/`archived`/`NULL`), scoped to `type='project'`. Denominator is all tracked projects, including unscored ones.
- Optional `scope` string param (`all` default, `lf`, `other`) filters by `isLF`.

Deploy status: **deployed to both staging and production.** No fix required — pushed clean on the first attempt. Live validation confirms the lifecycle-label distribution and the `scope=lf`/`scope=other` split both sum exactly to `scope=all` for every label.

Jira: https://linuxfoundation.atlassian.net/browse/IN-1287
