### PR TITLE
feat: add health_score_report_signal_scores Tinybird pipe (IN-1288)

### DIFF
--- a/services/libs/tinybird/pipes/health_score_report_signal_scores.pipe
+++ b/services/libs/tinybird/pipes/health_score_report_signal_scores.pipe
@@ -1,0 +1,117 @@
+DESCRIPTION >
+    - `health_score_report_signal_scores.pipe` serves widget 03 "Where the strongest
+    repositories pull ahead" for the Health Score report (IN-1288, part of epic IN-1276
+    Health Score Coverage).
+    - Returns one row per signal (9 of the 11 catalogued signals — Known vulnerabilities and
+    Commit activity are omitted here per the design): the 80th-percentile ("top 20% of
+    repositories") and median ("typical repository") score, each expressed as a percent of
+    the signal's max points.
+    - Only repos where that signal's availability flag is `1` are counted — a repo with no
+    measured value for a signal doesn't drag its percentile/median down.
+    - `signal_key` / `category_key` — same catalogue keys as `health_score_report_signal_availability`.
+    - `p80_pct` — `quantileExact(0.8)(score) / max_pts * 100`.
+    - `median_pct` — `median(score) / max_pts * 100`.
+    - `repos` — count of repos with that signal available (the denominator behind both percentiles).
+    - No parameters — this pipe is not scope-filtered.
+
+TOKEN "insights-app-token" READ
+
+TAGS "Insights, Widget", "Health"
+
+NODE health_score_report_signal_scores_tracked_repos
+SQL >
+    SELECT url
+    FROM repositories FINAL
+    WHERE deletedAt IS NULL AND excluded = false
+
+NODE health_score_report_signal_scores_endpoint
+SQL >
+    SELECT
+        'busFactor' AS signal_key,
+        'maintainerHealth' AS category_key,
+        quantileExact(0.8)(sd.busFactorScore) / 18 * 100 AS p80_pct,
+        median(sd.busFactorScore) / 18 * 100 AS median_pct,
+        count() AS repos
+    FROM health_score_report_signal_scores_tracked_repos AS r
+    JOIN health_score_v2_signal_detail_ds AS sd ON sd.repoUrl = r.url
+    WHERE sd.busFactorAvailable = 1
+    UNION ALL
+    SELECT
+        'orgDiversity',
+        'maintainerHealth',
+        quantileExact(0.8)(sd.orgDiversityScore) / 7 * 100,
+        median(sd.orgDiversityScore) / 7 * 100,
+        count()
+    FROM health_score_report_signal_scores_tracked_repos AS r
+    JOIN health_score_v2_signal_detail_ds AS sd ON sd.repoUrl = r.url
+    WHERE sd.orgDiversityAvailable = 1
+    UNION ALL
+    SELECT
+        'responsiveness',
+        'maintainerHealth',
+        quantileExact(0.8)(sd.responsivenessScore) / 15 * 100,
+        median(sd.responsivenessScore) / 15 * 100,
+        count()
+    FROM health_score_report_signal_scores_tracked_repos AS r
+    JOIN health_score_v2_signal_detail_ds AS sd ON sd.repoUrl = r.url
+    WHERE sd.responsivenessAvailable = 1
+    UNION ALL
+    SELECT
+        'scorecard',
+        'securitySupplyChain',
+        quantileExact(0.8)(sd.scorecardScorePts) / 8 * 100,
+        median(sd.scorecardScorePts) / 8 * 100,
+        count()
+    FROM health_score_report_signal_scores_tracked_repos AS r
+    JOIN health_score_v2_signal_detail_ds AS sd ON sd.repoUrl = r.url
+    WHERE sd.scorecardAvailable = 1
+    UNION ALL
+    SELECT
+        'securityPractices',
+        'securitySupplyChain',
+        quantileExact(0.8)(sd.securityPracticesScore) / 8 * 100,
+        median(sd.securityPracticesScore) / 8 * 100,
+        count()
+    FROM health_score_report_signal_scores_tracked_repos AS r
+    JOIN health_score_v2_signal_detail_ds AS sd ON sd.repoUrl = r.url
+    WHERE sd.securityPracticesAvailable = 1
+    UNION ALL
+    SELECT
+        'dependencyHealth',
+        'securitySupplyChain',
+        quantileExact(0.8)(sd.dependencyHealthScore) / 7 * 100,
+        median(sd.dependencyHealthScore) / 7 * 100,
+        count()
+    FROM health_score_report_signal_scores_tracked_repos AS r
+    JOIN health_score_v2_signal_detail_ds AS sd ON sd.repoUrl = r.url
+    WHERE sd.dependencyHealthAvailable = 1
+    UNION ALL
+    SELECT
+        'releaseCadence',
+        'developmentActivity',
+        quantileExact(0.8)(sd.releaseCadenceScore) / 8 * 100,
+        median(sd.releaseCadenceScore) / 8 * 100,
+        count()
+    FROM health_score_report_signal_scores_tracked_repos AS r
+    JOIN health_score_v2_signal_detail_ds AS sd ON sd.repoUrl = r.url
+    WHERE sd.releaseCadenceAvailable = 1
+    UNION ALL
+    SELECT
+        'issueResolution',
+        'developmentActivity',
+        quantileExact(0.8)(sd.issueResolutionScore) / 7 * 100,
+        median(sd.issueResolutionScore) / 7 * 100,
+        count()
+    FROM health_score_report_signal_scores_tracked_repos AS r
+    JOIN health_score_v2_signal_detail_ds AS sd ON sd.repoUrl = r.url
+    WHERE sd.issueResolutionAvailable = 1
+    UNION ALL
+    SELECT
+        'prMerge',
+        'developmentActivity',
+        quantileExact(0.8)(sd.prMergeScore) / 5 * 100,
+        median(sd.prMergeScore) / 5 * 100,
+        count()
+    FROM health_score_report_signal_scores_tracked_repos AS r
+    JOIN health_score_v2_signal_detail_ds AS sd ON sd.repoUrl = r.url
+    WHERE sd.prMergeAvailable = 1


### PR DESCRIPTION
## Summary

Adds `health_score_report_signal_scores.pipe`, the crowd.dev-side Tinybird pipe for widget 03
("Where the strongest repositories pull ahead") of the Health Score Coverage report (epic IN-1276).

Returns one row per signal (9 of the 11 catalogued signals — Known vulnerabilities and Commit
activity are omitted per the design): p80 ("top 20% of repos") and median ("typical repo") score,
each expressed as percent of the signal's max points, plus the repos count backing both figures.

## Validation

Validated against production via `mcp__tinybird__execute_query` (read-only, no deploy):

- All `p80_pct`/`median_pct` values fall in `0..100`
- `median_pct <= p80_pct` for every signal
- `repos` counts per signal match `health_score_report_signal_availability`'s already-validated
  per-signal availability counts (IN-1290, #4581) — busFactor 17776, orgDiversity 20497,
  responsiveness 26054, scorecard 7843, securityPractices 12256, dependencyHealth 12205,
  releaseCadence 4486, issueResolution 14374, prMerge 19054

## Deploy status — DEPLOYED

**Deployed to production.** Staging deploy failed as expected (known datasource-sync gap —
`health_score_v2_signal_detail_ds` not yet mirrored to `lfx_insights_stg`). No fix needed for
production — pushed clean on the first attempt. Post-deploy validation confirms all 9 signal rows
still hold, with `repos` per signal matching IN-1290's live availability counts exactly.

## Scope note

Insights-side implementation for this widget is out of scope for this pass — a separate insights
PR against the `release/IN-1276-health-score-coverage` branch will follow once this pipe is live.

---

After 30th June 2026, usage of the HTTP+SSE transport endpoint at https://mcp.atlassian.com/v1/sse
will no longer be supported. Recommend clients to point to the Streamable HTTP transport endpoint
at https://mcp.atlassian.com/v1/mcp.
https://community.atlassian.com/forums/Atlassian-Remote-MCP-Server/HTTP-SSE-Deprecation-Notice/ba-p/3205484
