### PR TITLE
feat: add health_score_report_category_coverage Tinybird pipe (IN-1289)

### DIFF
--- a/services/libs/tinybird/pipes/health_score_report_category_coverage.pipe
+++ b/services/libs/tinybird/pipes/health_score_report_category_coverage.pipe
@@ -1,0 +1,24 @@
+DESCRIPTION >
+    - `health_score_report_category_coverage.pipe` serves widget 04 "Repositories we can
+    score, by category" for the Health Score report (IN-1289, part of epic IN-1276 Health
+    Score Coverage).
+    - Three bars: Maintainer health, Development activity, Security & supply chain — each the
+    count (and, in the UI, percent) of tracked repositories with a non-null category score.
+    - `repos_tracked` is the shared denominator for all three bars and must equal the
+    "Repositories tracked" KPI for the same day.
+    - No parameters — this pipe is not scope-filtered.
+
+TOKEN "insights-app-token" READ
+
+TAGS "Insights, Widget", "Health"
+
+NODE health_score_report_category_coverage_endpoint
+SQL >
+    SELECT
+        countIf(rc.maintainerHealthScoreV2 IS NOT NULL) AS maintainer_health_scored,
+        countIf(rc.developmentActivityScoreV2 IS NOT NULL) AS development_activity_scored,
+        countIf(rc.securitySupplyChainScoreV2 IS NOT NULL) AS security_supply_chain_scored,
+        count() AS repos_tracked
+    FROM repositories AS r FINAL
+    LEFT JOIN health_score_v2_repo_copy_ds AS rc ON rc.repoUrl = r.url
+    WHERE r.deletedAt IS NULL AND r.excluded = false


### PR DESCRIPTION
## Summary

Adds `health_score_report_category_coverage.pipe`, the crowd.dev-side Tinybird pipe for widget
04 ("Repositories we can score, by category") of the Health Score Coverage report (epic
IN-1276).

Returns the count of tracked repositories with a non-null score for each of the three
categories (maintainer health, development activity, security & supply chain), plus the shared
`repos_tracked` denominator.

## Validation

Validated against production via `mcp__tinybird__execute_query` (read-only, no deploy):

- `maintainer_health_scored` 20665, `development_activity_scored` 19908,
  `security_supply_chain_scored` 12284, `repos_tracked` 31593
- `repos_tracked` matches the already-validated tracked-repo total from
  `health_score_report_signal_availability` (IN-1290, #4581)

## Deploy status — DEPLOYED

**Deployed to both staging and production.** No fix needed — staging actually succeeded this
time (the datasource-sync gap seen on other pipes in this epic did not reproduce here). Post-deploy
validation confirms the same figures as the pre-deploy read-only check, with `repos_tracked`
matching the KPI total (31593).

## Scope note

Insights-side implementation for this widget is out of scope for this pass — a separate insights
PR against the `release/IN-1276-health-score-coverage` branch will follow once this pipe is
live.

---

After 30th June 2026, usage of the HTTP+SSE transport endpoint at https://mcp.atlassian.com/v1/sse
will no longer be supported. Recommend clients to point to the Streamable HTTP transport endpoint
at https://mcp.atlassian.com/v1/mcp.
https://community.atlassian.com/forums/Atlassian-Remote-MCP-Server/HTTP-SSE-Deprecation-Notice/ba-p/3205484
