### PR TITLE
feat: add health_score_report_category_maximum Tinybird pipe (IN-1292)

### DIFF
--- a/services/libs/tinybird/pipes/health_score_report_category_maximum.pipe
+++ b/services/libs/tinybird/pipes/health_score_report_category_maximum.pipe
@@ -1,0 +1,24 @@
+DESCRIPTION >
+    - `health_score_report_category_maximum.pipe` serves widget 07 "Repositories scoring full
+    marks" for the Health Score report (IN-1292, part of epic IN-1276 Health Score Coverage).
+    - A three-row table — Maintainer health (max 40), Development activity (max 25), Security
+    & supply chain (max 35) — with the count of tracked repos hitting each category's exact
+    maximum score.
+    - Security & supply chain requires all four of its signals present and strong at once, so
+    it is expected to be the hardest category to max out.
+    - No parameters — this pipe is not scope-filtered.
+
+TOKEN "insights-app-token" READ
+
+TAGS "Insights, Widget", "Health"
+
+NODE health_score_report_category_maximum_endpoint
+SQL >
+    SELECT
+        countIf(rc.maintainerHealthScoreV2 = 40) AS maintainer_health_max,
+        countIf(rc.developmentActivityScoreV2 = 25) AS development_activity_max,
+        countIf(rc.securitySupplyChainScoreV2 = 35) AS security_supply_chain_max,
+        count() AS repos_tracked
+    FROM repositories AS r FINAL
+    LEFT JOIN health_score_v2_repo_copy_ds AS rc ON rc.repoUrl = r.url
+    WHERE r.deletedAt IS NULL AND r.excluded = false

--- a/services/libs/tinybird/pipes/health_score_report_github_security.pipe
+++ b/services/libs/tinybird/pipes/health_score_report_github_security.pipe
@@ -34,16 +34,12 @@ SQL >
     LEFT JOIN insights_projects_populated_ds AS p ON p.id = r.insightsProjectId
     LEFT JOIN health_score_v2_signal_detail_ds AS sd ON sd.repoUrl = r.url
     LEFT JOIN health_score_v2_repo_copy_ds AS rc ON rc.repoUrl = r.url
-    WHERE
-        r.deletedAt IS NULL
-        AND r.excluded = false
-        AND r.url LIKE 'https://github.com/%'
+    WHERE r.deletedAt IS NULL AND r.excluded = false AND r.url LIKE 'https://github.com/%'
     GROUP BY isLF
 
 NODE health_score_report_github_security_lf_non_github
 SQL >
-    SELECT
-        countIf(p.isLF = 1 AND r.url NOT LIKE 'https://github.com/%') AS lf_non_github
+    SELECT countIf(p.isLF = 1 AND r.url NOT LIKE 'https://github.com/%') AS lf_non_github
     FROM repositories AS r FINAL
     LEFT JOIN insights_projects_populated_ds AS p ON p.id = r.insightsProjectId
     WHERE r.deletedAt IS NULL AND r.excluded = false

--- a/services/libs/tinybird/pipes/health_score_report_signal_scores.pipe
+++ b/services/libs/tinybird/pipes/health_score_report_signal_scores.pipe
@@ -20,16 +20,15 @@ TAGS "Insights, Widget", "Health"
 
 NODE health_score_report_signal_scores_tracked_repos
 SQL >
-    SELECT url
-    FROM repositories FINAL
-    WHERE deletedAt IS NULL AND excluded = false
+    SELECT url FROM repositories FINAL WHERE deletedAt IS NULL AND excluded = false
 
 NODE health_score_report_signal_scores_endpoint
 SQL >
     SELECT
         'busFactor' AS signal_key,
         'maintainerHealth' AS category_key,
-        quantileExact(0.8)(sd.busFactorScore) / 18 * 100 AS p80_pct,
+        quantileExact(0.8)
+        (sd.busFactorScore) / 18 * 100 AS p80_pct,
         median(sd.busFactorScore) / 18 * 100 AS median_pct,
         count() AS repos
     FROM health_score_report_signal_scores_tracked_repos AS r
@@ -39,7 +38,8 @@ SQL >
     SELECT
         'orgDiversity',
         'maintainerHealth',
-        quantileExact(0.8)(sd.orgDiversityScore) / 7 * 100,
+        quantileExact(0.8)
+        (sd.orgDiversityScore) / 7 * 100,
         median(sd.orgDiversityScore) / 7 * 100,
         count()
     FROM health_score_report_signal_scores_tracked_repos AS r
@@ -49,7 +49,8 @@ SQL >
     SELECT
         'responsiveness',
         'maintainerHealth',
-        quantileExact(0.8)(sd.responsivenessScore) / 15 * 100,
+        quantileExact(0.8)
+        (sd.responsivenessScore) / 15 * 100,
         median(sd.responsivenessScore) / 15 * 100,
         count()
     FROM health_score_report_signal_scores_tracked_repos AS r
@@ -59,7 +60,8 @@ SQL >
     SELECT
         'scorecard',
         'securitySupplyChain',
-        quantileExact(0.8)(sd.scorecardScorePts) / 8 * 100,
+        quantileExact(0.8)
+        (sd.scorecardScorePts) / 8 * 100,
         median(sd.scorecardScorePts) / 8 * 100,
         count()
     FROM health_score_report_signal_scores_tracked_repos AS r
@@ -69,7 +71,8 @@ SQL >
     SELECT
         'securityPractices',
         'securitySupplyChain',
-        quantileExact(0.8)(sd.securityPracticesScore) / 8 * 100,
+        quantileExact(0.8)
+        (sd.securityPracticesScore) / 8 * 100,
         median(sd.securityPracticesScore) / 8 * 100,
         count()
     FROM health_score_report_signal_scores_tracked_repos AS r
@@ -79,7 +82,8 @@ SQL >
     SELECT
         'dependencyHealth',
         'securitySupplyChain',
-        quantileExact(0.8)(sd.dependencyHealthScore) / 7 * 100,
+        quantileExact(0.8)
+        (sd.dependencyHealthScore) / 7 * 100,
         median(sd.dependencyHealthScore) / 7 * 100,
         count()
     FROM health_score_report_signal_scores_tracked_repos AS r
@@ -89,7 +93,8 @@ SQL >
     SELECT
         'releaseCadence',
         'developmentActivity',
-        quantileExact(0.8)(sd.releaseCadenceScore) / 8 * 100,
+        quantileExact(0.8)
+        (sd.releaseCadenceScore) / 8 * 100,
         median(sd.releaseCadenceScore) / 8 * 100,
         count()
     FROM health_score_report_signal_scores_tracked_repos AS r
@@ -99,7 +104,8 @@ SQL >
     SELECT
         'issueResolution',
         'developmentActivity',
-        quantileExact(0.8)(sd.issueResolutionScore) / 7 * 100,
+        quantileExact(0.8)
+        (sd.issueResolutionScore) / 7 * 100,
         median(sd.issueResolutionScore) / 7 * 100,
         count()
     FROM health_score_report_signal_scores_tracked_repos AS r
@@ -109,7 +115,8 @@ SQL >
     SELECT
         'prMerge',
         'developmentActivity',
-        quantileExact(0.8)(sd.prMergeScore) / 5 * 100,
+        quantileExact(0.8)
+        (sd.prMergeScore) / 5 * 100,
         median(sd.prMergeScore) / 5 * 100,
         count()
     FROM health_score_report_signal_scores_tracked_repos AS r


### PR DESCRIPTION
## Summary

Adds `health_score_report_category_maximum.pipe`, the crowd.dev-side Tinybird pipe for widget
07 ("Repositories scoring full marks") of the Health Score Coverage report (epic IN-1276).

Returns the count of tracked repositories hitting each category's exact maximum score:
maintainer health (40), development activity (25), security & supply chain (35).

## Validation

Validated against production via `mcp__tinybird__execute_query` (read-only, no deploy):

- `maintainer_health_max` 4679, `development_activity_max` 1442,
  `security_supply_chain_max` 135, `repos_tracked` 31593
- Security & supply chain is by far the hardest category to max out — consistent with the
  design's stated expectation that it needs all four of its signals present and strong at once

## Deploy status — DEPLOYED

**Deployed to both staging and production.** No pipe-code fix was needed — production push
initially failed with a stale `.tinyb` CLI-cache artifact (`Release 5.19.0 not found`, an
unrelated local tooling issue resolved by resetting the cached `.tinyb` `semver`/`version`), then
succeeded cleanly. Post-deploy validation confirms the same figures as the pre-deploy read-only
check, with `repos_tracked` (31593) running slightly ahead of `health_score_report_kpis`'
snapshot-based total (31546) due to ordinary COPY-pipe refresh lag, not a data bug.

## Scope note

Insights-side implementation for this widget is out of scope for this pass — a separate insights
PR against the `release/IN-1276-health-score-coverage` branch will follow once this pipe is
live.

---

After 30th June 2026, usage of the HTTP+SSE transport endpoint at https://mcp.atlassian.com/v1/sse
will no longer be supported. Recommend clients to point to the Streamable HTTP transport endpoint
at https://mcp.atlassian.com/v1/mcp.
https://community.atlassian.com/forums/Atlassian-Remote-MCP-Server/HTTP-SSE-Deprecation-Notice/ba-p/3205484
