### PR TITLE
fix: distinguish resolve 409s via `context.reason`

### DIFF
--- a/backend/src/api/public/openapi.yaml
+++ b/backend/src/api/public/openapi.yaml
@@ -191,7 +191,9 @@ paths:
         '409':
           description: >
             Multiple member profiles matched, or the matched member holds a
-            verified LFID that is not among the supplied lfids.
+            verified LFID that is not among the supplied lfids. Distinguish the
+            two cases with error.context.reason (`multi-match` or
+            `foreign-lfid`).
           content:
             application/json:
               schema:
@@ -203,12 +205,21 @@ paths:
                     error:
                       code: CONFLICT
                       message: Multiple member profiles matched
+                      context:
+                        reason: multi-match
+                        memberIds:
+                          - 550e8400-e29b-41d4-a716-446655440000
+                          - 6ba7b810-9dad-11d1-80b4-00c04fd430c8
                 foreignLfid:
                   summary: Matched member holds a different LFID
                   value:
                     error:
                       code: CONFLICT
                       message: Member holds a different LFID
+                      context:
+                        reason: foreign-lfid
+                        lfids:
+                          - other-person-lfid
         '429':
           description: Per-client rate limit exceeded (200 req/min).
           headers:
@@ -1652,6 +1663,10 @@ components:
             message:
               type: string
               description: Human-readable error description.
+            context:
+              type: object
+              additionalProperties: true
+              description: Optional structured details for this error.
 
   responses:
     BadRequest:

--- a/backend/src/api/public/v1/members/resolveMember.ts
+++ b/backend/src/api/public/v1/members/resolveMember.ts
@@ -38,7 +38,10 @@ export async function resolveMemberByIdentities(req: Request, res: Response): Pr
   if (memberIds.length === 0) {
     throw new NotFoundError('Member not found')
   } else if (memberIds.length > 1) {
-    throw new ConflictError('Multiple member profiles matched', { memberIds })
+    throw new ConflictError('Multiple member profiles matched', {
+      reason: 'multi-match',
+      memberIds,
+    })
   }
 
   const memberId = memberIds[0]
@@ -52,15 +55,18 @@ export async function resolveMemberByIdentities(req: Request, res: Response): Pr
           identity.platform === PlatformType.LFID &&
           identity.type === MemberIdentityType.USERNAME,
       )
-      .map((identity) => identity.value.toLowerCase())
+      .map((identity) => identity.value)
 
     const suppliedLfids = new Set(lfids.map((lfid) => lfid.toLowerCase()))
-    const holdsSuppliedLfid = memberLfids.some((lfid) => suppliedLfids.has(lfid))
+    const holdsSuppliedLfid = memberLfids.some((lfid) => suppliedLfids.has(lfid.toLowerCase()))
 
     // Email can match a member that was never looked up by LFID. If that member
     // already has a different verified LFID, treat it as a conflict.
     if (memberLfids.length > 0 && !holdsSuppliedLfid) {
-      throw new ConflictError('Member holds a different LFID')
+      throw new ConflictError('Member holds a different LFID', {
+        reason: 'foreign-lfid',
+        lfids: memberLfids,
+      })
     }
   }
 


### PR DESCRIPTION
## Summary
`POST /v1/members/resolve` currently returns `409` for both multi-match and foreign-LFID, and callers can only tell them apart by parsing `message`. This adds a machine-readable `error.context.reason` so they can branch without pinning on text.

Related: linuxfoundation/segment-web-scripts#47

## Changes
- Set `context.reason` to `multi-match` or `foreign-lfid` on resolve 409s
- Include the matched member's verified LFIDs on the foreign-LFID 409
- Document `context` and both 409 examples in OpenAPI