### PR TITLE
chore: process existing fake organizations (CM-1413)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
     "script:fix-duplicate-members": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true tsx src/bin/scripts/fix-duplicate-members.ts",
     "script:fix-members-activities-after-unaffilation": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true tsx src/bin/scripts/fix-members-activities-after-unaffilation.ts",
     "script:process-bot-members": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true tsx src/bin/scripts/process-bot-members.ts",
+    "script:process-fake-organizations": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true tsx src/bin/scripts/process-fake-organizations.ts",
     "script:backfill-email-domain-member-organization-dates": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true tsx src/bin/scripts/backfill-email-domain-member-organization-dates.ts",
     "script:onboard-default-tenant": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true tsx src/bin/scripts/onboard-default-tenant.ts",
     "script:onboard-default-tenant:local": "set -a && . ./.env.dist.local && . ./.env.override.local && set +a && pnpm run script:onboard-default-tenant",

--- a/backend/src/bin/scripts/process-fake-organizations.ts
+++ b/backend/src/bin/scripts/process-fake-organizations.ts
@@ -91,10 +91,7 @@ setImmediate(async () => {
 
     if (organizationIds.length > 0) {
       afterOrganizationId = organizationIds[organizationIds.length - 1]
-      log.info(
-        { afterOrganizationId, count: organizationIds.length },
-        'Batch processed!',
-      )
+      log.info({ afterOrganizationId, count: organizationIds.length }, 'Batch processed!')
     }
 
     if (testRun) {

--- a/backend/src/bin/scripts/process-fake-organizations.ts
+++ b/backend/src/bin/scripts/process-fake-organizations.ts
@@ -3,11 +3,14 @@ import commandLineArgs from 'command-line-args'
 import { DEFAULT_TENANT_ID } from '@crowd/common'
 import { fetchFakeOrganizationAnalysisCandidates, pgpQx } from '@crowd/data-access-layer'
 import { getDbConnection } from '@crowd/data-access-layer/src/database'
+import { chunkArray } from '@crowd/data-access-layer/src/old/apps/merge_suggestions_worker/utils'
 import { getServiceLogger } from '@crowd/logging'
 import { getTemporalClient } from '@crowd/temporal'
 import { TemporalWorkflowId } from '@crowd/types'
 
 import { DB_CONFIG, TEMPORAL_CONFIG } from '@/conf'
+
+const CONCURRENCY = 100
 
 const log = getServiceLogger()
 
@@ -36,7 +39,7 @@ const parameters = commandLineArgs(options)
 
 setImmediate(async () => {
   const testRun = parameters.testRun ?? false
-  const BATCH_SIZE = testRun ? 10 : 100
+  const BATCH_SIZE = testRun ? 10 : 1000
   let afterOrganizationId = parameters.afterOrganizationId ?? undefined
 
   const db = await getDbConnection({
@@ -51,7 +54,7 @@ setImmediate(async () => {
   const temporal = await getTemporalClient(TEMPORAL_CONFIG)
 
   log.info(
-    { testRun, BATCH_SIZE, afterOrganizationId },
+    { testRun, BATCH_SIZE, CONCURRENCY, afterOrganizationId },
     'Running script with the following parameters!',
   )
 
@@ -64,29 +67,33 @@ setImmediate(async () => {
       afterOrganizationId,
     )
 
-    for (const organizationId of organizationIds) {
-      log.info({ organizationId }, 'Triggering workflow for organization!')
+    for (const chunk of chunkArray(organizationIds, CONCURRENCY)) {
+      await Promise.all(
+        chunk.map(async (organizationId) => {
+          log.info({ organizationId }, 'Triggering workflow for organization!')
 
-      const workflowId = `${TemporalWorkflowId.FAKE_ORGANIZATION_ANALYSIS_WITH_LLM}/${organizationId}`
+          const workflowId = `${TemporalWorkflowId.FAKE_ORGANIZATION_ANALYSIS_WITH_LLM}/${organizationId}`
 
-      try {
-        await temporal.workflow.start('fakeOrganizationAnalysisWithLLM', {
-          taskQueue: 'profiles',
-          workflowId,
-          retry: {
-            maximumAttempts: 10,
-          },
-          args: [{ organizationId }],
-          searchAttributes: {
-            TenantId: [DEFAULT_TENANT_ID],
-          },
-        })
+          try {
+            await temporal.workflow.start('fakeOrganizationAnalysisWithLLM', {
+              taskQueue: 'profiles',
+              workflowId,
+              retry: {
+                maximumAttempts: 10,
+              },
+              args: [{ organizationId }],
+              searchAttributes: {
+                TenantId: [DEFAULT_TENANT_ID],
+              },
+            })
 
-        await temporal.workflow.result(workflowId)
-      } catch (err) {
-        log.error({ organizationId, err }, 'Failed to trigger workflow for organization!')
-        throw err
-      }
+            await temporal.workflow.result(workflowId)
+          } catch (err) {
+            log.error({ organizationId, err }, 'Failed to trigger workflow for organization!')
+            throw err
+          }
+        }),
+      )
     }
 
     if (organizationIds.length > 0) {

--- a/backend/src/bin/scripts/process-fake-organizations.ts
+++ b/backend/src/bin/scripts/process-fake-organizations.ts
@@ -1,0 +1,107 @@
+import commandLineArgs from 'command-line-args'
+
+import { DEFAULT_TENANT_ID } from '@crowd/common'
+import { fetchFakeOrganizationAnalysisCandidates, pgpQx } from '@crowd/data-access-layer'
+import { getDbConnection } from '@crowd/data-access-layer/src/database'
+import { getServiceLogger } from '@crowd/logging'
+import { getTemporalClient } from '@crowd/temporal'
+import { TemporalWorkflowId } from '@crowd/types'
+
+import { DB_CONFIG, TEMPORAL_CONFIG } from '@/conf'
+
+const log = getServiceLogger()
+
+const options = [
+  {
+    name: 'testRun',
+    alias: 't',
+    type: Boolean,
+    description: 'Run in test mode (limit to 10 organizations).',
+  },
+  {
+    name: 'afterOrganizationId',
+    alias: 'a',
+    type: String,
+    description: 'The organization ID to start processing after.',
+  },
+  {
+    name: 'help',
+    alias: 'h',
+    type: Boolean,
+    description: 'Print this usage guide.',
+  },
+]
+
+const parameters = commandLineArgs(options)
+
+setImmediate(async () => {
+  const testRun = parameters.testRun ?? false
+  const BATCH_SIZE = testRun ? 10 : 100
+  let afterOrganizationId = parameters.afterOrganizationId ?? undefined
+
+  const db = await getDbConnection({
+    host: DB_CONFIG.readHost,
+    port: DB_CONFIG.port,
+    database: DB_CONFIG.database,
+    user: DB_CONFIG.username,
+    password: DB_CONFIG.password,
+  })
+
+  const qx = pgpQx(db)
+  const temporal = await getTemporalClient(TEMPORAL_CONFIG)
+
+  log.info(
+    { testRun, BATCH_SIZE, afterOrganizationId },
+    'Running script with the following parameters!',
+  )
+
+  let organizationIds: string[] = []
+
+  do {
+    organizationIds = await fetchFakeOrganizationAnalysisCandidates(
+      qx,
+      BATCH_SIZE,
+      afterOrganizationId,
+    )
+
+    for (const organizationId of organizationIds) {
+      log.info({ organizationId }, 'Triggering workflow for organization!')
+
+      const workflowId = `${TemporalWorkflowId.FAKE_ORGANIZATION_ANALYSIS_WITH_LLM}/${organizationId}`
+
+      try {
+        await temporal.workflow.start('fakeOrganizationAnalysisWithLLM', {
+          taskQueue: 'profiles',
+          workflowId,
+          retry: {
+            maximumAttempts: 10,
+          },
+          args: [{ organizationId }],
+          searchAttributes: {
+            TenantId: [DEFAULT_TENANT_ID],
+          },
+        })
+
+        await temporal.workflow.result(workflowId)
+      } catch (err) {
+        log.error({ organizationId, err }, 'Failed to trigger workflow for organization!')
+        throw err
+      }
+    }
+
+    if (organizationIds.length > 0) {
+      afterOrganizationId = organizationIds[organizationIds.length - 1]
+      log.info(
+        { afterOrganizationId, count: organizationIds.length },
+        'Batch processed!',
+      )
+    }
+
+    if (testRun) {
+      log.info('Test run - stopping after first batch!')
+      break
+    }
+  } while (organizationIds.length > 0)
+
+  process.exit(0)
+})

--- a/services/libs/data-access-layer/src/organizations/fake.ts
+++ b/services/libs/data-access-layer/src/organizations/fake.ts
@@ -10,6 +10,39 @@ type FakeOrganizationSuggestion = {
   activityCount: number
 }
 
+export async function fetchFakeOrganizationAnalysisCandidates(
+  qx: QueryExecutor,
+  limit: number,
+  afterOrganizationId?: string,
+): Promise<string[]> {
+  const rows = await qx.select(
+    `
+      SELECT DISTINCT o.id AS "organizationId"
+      FROM "organizationIdentities" oi
+      JOIN organizations o ON o.id = oi."organizationId"
+      WHERE oi.verified = true
+        AND oi.platform = 'email'
+        AND oi.type = 'primary-domain'
+        AND oi.source = 'email-domain'
+        AND o."deletedAt" IS NULL
+        AND o."createdAt" < now() - interval '1 day'
+        ${afterOrganizationId ? `AND o.id > $(afterOrganizationId)` : ''}
+        AND (
+          SELECT COUNT(*)
+          FROM "memberOrganizations" mo
+          JOIN members m ON m.id = mo."memberId" AND m."deletedAt" IS NULL
+          WHERE mo."organizationId" = o.id
+            AND mo."deletedAt" IS NULL
+        ) = 1
+      ORDER BY o.id
+      LIMIT $(limit)
+    `,
+    { limit, afterOrganizationId },
+  )
+
+  return rows.map((r) => r.organizationId)
+}
+
 export async function insertFakeOrganizationSuggestions(
   qx: QueryExecutor,
   organizationIds: string[],

--- a/services/libs/data-access-layer/src/organizations/fake.ts
+++ b/services/libs/data-access-layer/src/organizations/fake.ts
@@ -1,4 +1,4 @@
-import { PageData } from '@crowd/types'
+import { LlmQueryType, PageData } from '@crowd/types'
 
 import { QueryExecutor } from '../queryExecutor'
 import { prepareBulkInsert } from '../utils'
@@ -23,21 +23,37 @@ export async function fetchFakeOrganizationAnalysisCandidates(
       WHERE oi.verified = true
         AND oi.platform = 'email'
         AND oi.type = 'primary-domain'
-        AND oi.source = 'email-domain'
         AND o."deletedAt" IS NULL
         AND o."createdAt" < now() - interval '1 day'
         ${afterOrganizationId ? `AND o.id > $(afterOrganizationId)` : ''}
+        AND EXISTS (
+          SELECT 1
+          FROM "memberOrganizations" mo
+          WHERE mo."organizationId" = o.id
+            AND mo.source = 'email-domain'
+            AND mo."deletedAt" IS NULL
+        )
         AND (
-          SELECT COUNT(*)
+          SELECT COUNT(DISTINCT mo."memberId")
           FROM "memberOrganizations" mo
           JOIN members m ON m.id = mo."memberId" AND m."deletedAt" IS NULL
           WHERE mo."organizationId" = o.id
             AND mo."deletedAt" IS NULL
         ) = 1
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "llmPromptHistory" h
+          WHERE h.type = $(type)
+            AND h."entityId" = o.id::text
+        )
       ORDER BY o.id
       LIMIT $(limit)
     `,
-    { limit, afterOrganizationId },
+    {
+      limit,
+      afterOrganizationId,
+      type: LlmQueryType.FAKE_ORGANIZATION_ANALYSIS,
+    },
   )
 
   return rows.map((r) => r.organizationId)


### PR DESCRIPTION
## Summary
- Runs `fakeOrganizationAnalysisWithLLM` on existing email-domain orgs that predate the create-path trigger.

## Changes
- Script with keyset pagination, sequential workflow starts, `--testRun` and `--afterOrganizationId` flags.
- DAL fetch for candidates: email-domain origin, one active member, older than a day.