### PR TITLE
feat: add CNCF maintainers.yaml detector and parser (CM-1403)

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/maintainer/cncf_maintainers.py
+++ b/services/apps/git_integration/src/crowdgit/services/maintainer/cncf_maintainers.py
@@ -64,4 +64,5 @@ def parse_cncf_maintainers_yaml(content: str) -> list[MaintainerInfoItem] | None
     return [
         MaintainerInfoItem(github_username=member, normalized_title="maintainer")
         for member in members
+        if isinstance(member, str)
     ]

--- a/services/apps/git_integration/src/crowdgit/services/maintainer/cncf_maintainers.py
+++ b/services/apps/git_integration/src/crowdgit/services/maintainer/cncf_maintainers.py
@@ -62,7 +62,9 @@ def parse_cncf_maintainers_yaml(content: str) -> list[MaintainerInfoItem] | None
         return None
 
     return [
-        MaintainerInfoItem(github_username=member, normalized_title="maintainer")
+        MaintainerInfoItem(
+            github_username=member, title="maintainer", normalized_title="maintainer"
+        )
         for member in members
         if isinstance(member, str)
     ]

--- a/services/apps/git_integration/src/crowdgit/services/maintainer/cncf_maintainers.py
+++ b/services/apps/git_integration/src/crowdgit/services/maintainer/cncf_maintainers.py
@@ -51,6 +51,8 @@ def parse_cncf_maintainers_yaml(content: str) -> list[MaintainerInfoItem] | None
         for team in teams:
             if not isinstance(team, dict):
                 return None
+            if "emeritus" in str(team.get("name", "")).lower():
+                continue
             team_members = team.get("members")
             if not isinstance(team_members, list):
                 return None

--- a/services/apps/git_integration/src/crowdgit/services/maintainer/cncf_maintainers.py
+++ b/services/apps/git_integration/src/crowdgit/services/maintainer/cncf_maintainers.py
@@ -13,7 +13,10 @@ def is_cncf_repo(repo_url: str) -> bool:
         _, repo_name = parse_repo_url(repo_url)
     except Exception:
         return False
-    return repo_name.lower() == ".project"
+    repo_name = repo_name.lower()
+    if repo_name.endswith(".git"):
+        repo_name = repo_name[: -len(".git")]
+    return repo_name == ".project"
 
 
 def find_cncf_maintainers_file(repo_path: Path) -> Path | None:

--- a/services/apps/git_integration/src/crowdgit/services/maintainer/cncf_maintainers.py
+++ b/services/apps/git_integration/src/crowdgit/services/maintainer/cncf_maintainers.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+import yaml
+
+from crowdgit.models.maintainer_info import MaintainerInfoItem
+from crowdgit.services.utils import parse_repo_url
+
+CNCF_MAINTAINERS_FILENAMES = ("maintainers.yaml", "maintainers.yml")
+
+
+def is_cncf_repo(repo_url: str) -> bool:
+    try:
+        _, repo_name = parse_repo_url(repo_url)
+    except Exception:
+        return False
+    return repo_name.lower() == ".project"
+
+
+def find_cncf_maintainers_file(repo_path: Path) -> Path | None:
+    repo_path = Path(repo_path)
+    for filename in CNCF_MAINTAINERS_FILENAMES:
+        candidate = repo_path / filename
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def parse_cncf_maintainers_yaml(content: str) -> list[MaintainerInfoItem] | None:
+    try:
+        data = yaml.safe_load(content)
+    except yaml.YAMLError:
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    maintainer_entries = data.get("maintainers")
+    if not isinstance(maintainer_entries, list):
+        return None
+
+    members: list[str] = []
+    for entry in maintainer_entries:
+        if not isinstance(entry, dict):
+            return None
+        teams = entry.get("teams")
+        if not isinstance(teams, list):
+            return None
+        for team in teams:
+            if not isinstance(team, dict):
+                return None
+            team_members = team.get("members")
+            if not isinstance(team_members, list):
+                return None
+            members.extend(team_members)
+
+    if not members:
+        return None
+
+    return [
+        MaintainerInfoItem(github_username=member, normalized_title="maintainer")
+        for member in members
+    ]

--- a/services/apps/git_integration/src/crowdgit/services/maintainer/cncf_maintainers.py
+++ b/services/apps/git_integration/src/crowdgit/services/maintainer/cncf_maintainers.py
@@ -58,13 +58,13 @@ def parse_cncf_maintainers_yaml(content: str) -> list[MaintainerInfoItem] | None
                 return None
             members.extend(team_members)
 
-    if not members:
+    string_members = [member for member in members if isinstance(member, str)]
+    if not string_members:
         return None
 
     return [
         MaintainerInfoItem(
             github_username=member, title="maintainer", normalized_title="maintainer"
         )
-        for member in members
-        if isinstance(member, str)
+        for member in string_members
     ]


### PR DESCRIPTION
## Summary
- Adds an isolated, deterministic (no-LLM) detector/parser for CNCF `.project`-repo `maintainers.yaml`/`.yml` files: `is_cncf_repo`, `find_cncf_maintainers_file`, `parse_cncf_maintainers_yaml`.
- Not wired into `extract_maintainers` yet — this is PR1 of a 2-PR stack. PR2 will wire this in as a new Step 0 with fallback to existing behavior, enabling self-correction for repos already stuck on the wrong maintainer file.

## Test plan
- [x] `make test test=test_cncf_maintainers.py` — 8/8 unit tests pass
- [x] `make test` — full suite green
- [x] `ruff check` clean on new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)