### PR TITLE
feat: wire CNCF maintainers.yaml as self-correcting Step 0 (CM-1403)

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
@@ -796,8 +796,8 @@ class MaintainerService(BaseService):
             result.ai_suggested_file = ai_suggested_file
             return result
 
-        # Step 0: CNCF .project repos are authoritative via maintainers.yaml, re-checked
-        # every run so the pipeline self-corrects if it previously locked onto another file
+        # Runs before the saved-file shortcut so a repo already locked
+        # onto another file self-corrects.
         if is_cncf_repo(repo_url):
             cncf_file = find_cncf_maintainers_file(repo_path)
             if cncf_file:

--- a/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
@@ -39,6 +39,11 @@ from crowdgit.models.maintainer_info import (
 from crowdgit.models.service_execution import ServiceExecution
 from crowdgit.services.base.base_service import BaseService
 from crowdgit.services.llm.bedrock import invoke_bedrock
+from crowdgit.services.maintainer.cncf_maintainers import (
+    find_cncf_maintainers_file,
+    is_cncf_repo,
+    parse_cncf_maintainers_yaml,
+)
 from crowdgit.services.maintainer.section_extractor import SectionExtractor
 from crowdgit.services.utils import run_shell_command, safe_decode
 from crowdgit.settings import MAINTAINER_RETRY_INTERVAL_DAYS, MAINTAINER_UPDATE_INTERVAL_HOURS
@@ -790,6 +795,21 @@ class MaintainerService(BaseService):
             result.candidate_files = candidate_files
             result.ai_suggested_file = ai_suggested_file
             return result
+
+        # Step 0: CNCF .project repos are authoritative via maintainers.yaml, re-checked
+        # every run so the pipeline self-corrects if it previously locked onto another file
+        if is_cncf_repo(repo_url):
+            cncf_file = find_cncf_maintainers_file(repo_path)
+            if cncf_file:
+                content = await self._read_text_file(str(cncf_file))
+                cncf_maintainers = parse_cncf_maintainers_yaml(content)
+                if cncf_maintainers:
+                    return _attach_metadata(
+                        MaintainerResult(
+                            maintainer_file=cncf_file.name,
+                            maintainer_info=cncf_maintainers,
+                        )
+                    )
 
         # Step 1: Try the previously saved maintainer file
         if saved_maintainer_file:

--- a/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
@@ -801,8 +801,12 @@ class MaintainerService(BaseService):
         if is_cncf_repo(repo_url):
             cncf_file = find_cncf_maintainers_file(repo_path)
             if cncf_file:
-                content = await self._read_text_file(str(cncf_file))
-                cncf_maintainers = parse_cncf_maintainers_yaml(content)
+                try:
+                    content = await self._read_text_file(str(cncf_file))
+                    cncf_maintainers = parse_cncf_maintainers_yaml(content)
+                except Exception as e:
+                    self.logger.warning(f"CNCF maintainer file processing failed: {repr(e)}")
+                    cncf_maintainers = None
                 if cncf_maintainers:
                     return _attach_metadata(
                         MaintainerResult(

--- a/services/apps/git_integration/src/test/test_extract_maintainers_cncf.py
+++ b/services/apps/git_integration/src/test/test_extract_maintainers_cncf.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+import crowdgit.services.maintainer.maintainer_service as maintainer_service_module
+from crowdgit.services.maintainer.maintainer_service import MaintainerService
+
+CNCF_YAML = """
+maintainers:
+  - project_id: cri-o
+    org: cri-o
+    teams:
+      - name: maintainers
+        managed: true
+        members:
+          - alice
+          - bob
+"""
+
+
+@pytest.fixture
+def cncf_repo(tmp_path: Path) -> Path:
+    (tmp_path / "maintainers.yaml").write_text(CNCF_YAML)
+    (tmp_path / "CODEOWNERS").write_text("* @alice @bob @charlie\n")
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_extract_maintainers_bypasses_detection_for_cncf_repo(cncf_repo: Path):
+    service = MaintainerService()
+
+    result = await service.extract_maintainers(
+        str(cncf_repo),
+        saved_maintainer_file=None,
+        repo_url="https://github.com/cri-o/.project",
+    )
+
+    assert result.maintainer_file == "maintainers.yaml"
+    assert {m.github_username for m in result.maintainer_info} == {"alice", "bob"}
+
+
+@pytest.mark.asyncio
+async def test_extract_maintainers_self_corrects_when_stuck_on_wrong_file(cncf_repo: Path):
+    service = MaintainerService()
+
+    result = await service.extract_maintainers(
+        str(cncf_repo),
+        saved_maintainer_file="CODEOWNERS",
+        repo_url="https://github.com/cri-o/.project",
+    )
+
+    assert result.maintainer_file == "maintainers.yaml"
+    assert {m.github_username for m in result.maintainer_info} == {"alice", "bob"}
+
+
+@pytest.mark.asyncio
+async def test_extract_maintainers_falls_back_when_not_cncf_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    (tmp_path / "maintainers.yaml").write_text(CNCF_YAML)
+    service = MaintainerService()
+    monkeypatch.setattr(
+        service, "classify_candidates_with_ai", AsyncMock(return_value=(set(), 0.0))
+    )
+    monkeypatch.setattr(
+        service, "find_maintainer_file_with_ai", AsyncMock(return_value=(None, 0.0))
+    )
+
+    result = await service.extract_maintainers(
+        str(tmp_path),
+        saved_maintainer_file=None,
+        repo_url="https://github.com/cri-o/cri-o",
+    )
+
+    assert result.not_found is True
+
+
+@pytest.mark.asyncio
+async def test_extract_maintainers_falls_back_when_cncf_parsing_raises(
+    cncf_repo: Path, monkeypatch: pytest.MonkeyPatch
+):
+    service = MaintainerService()
+    monkeypatch.setattr(
+        maintainer_service_module,
+        "parse_cncf_maintainers_yaml",
+        lambda content: (_ for _ in ()).throw(ValueError("boom")),
+    )
+    monkeypatch.setattr(
+        service, "classify_candidates_with_ai", AsyncMock(return_value=(set(), 0.0))
+    )
+    monkeypatch.setattr(
+        service, "find_maintainer_file_with_ai", AsyncMock(return_value=(None, 0.0))
+    )
+
+    result = await service.extract_maintainers(
+        str(cncf_repo),
+        saved_maintainer_file=None,
+        repo_url="https://github.com/cri-o/.project",
+    )
+
+    assert result.not_found is True


### PR DESCRIPTION
## Summary
- Stacked on #4598. Wires the CNCF `.project` detector/parser into `extract_maintainers` as a new Step 0, run on every call (before the saved-file shortcut) — not just when no file is saved yet.
- On success: returns immediately, bypassing detection/AI/union entirely, and the returned `maintainer_file` overwrites whatever was previously saved in `"repositoryProcessing"."maintainerFile"` — this is what makes it self-correcting for repos already stuck on a non-`maintainers.yaml` file.
- On failure (not a `.project` repo, file missing, or parse/shape failure): falls through unchanged to existing detection/AI behavior.
- v1 simplification (agreed): every member of every team maps to `normalized_title = "maintainer"`, regardless of team name (`emeritus`, etc.) or `managed` flag.

## Test plan
- [x] `make test test=test_extract_maintainers_cncf.py` — 3/3: bypass for a clean CNCF repo, self-correction when stuck on `CODEOWNERS`, fallback preserved for non-CNCF repos with a `maintainers.yaml` present
- [x] `make test` — full suite green (15 passed)
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)