### PR TITLE
fix: use `identityId` for dissectMember force-split preview

### DIFF
--- a/services/apps/script_executor_worker/src/activities/common.ts
+++ b/services/apps/script_executor_worker/src/activities/common.ts
@@ -4,7 +4,6 @@ import { Error404 } from '@crowd/common'
 import { CommonMemberService, signalMemberUpdate } from '@crowd/common_services'
 import { pgpQx } from '@crowd/data-access-layer'
 import {
-  IMemberIdentity,
   IMemberUnmergeBackup,
   IMemberUnmergePreviewResult,
   IUnmergeBackup,
@@ -62,7 +61,7 @@ export async function unmergeMembers(
 
 export async function unmergeMembersPreview(
   memberId: string,
-  memberIdentity: IMemberIdentity,
+  identityId: string,
 ): Promise<IUnmergePreviewResult<IMemberUnmergePreviewResult>> {
   const url = `${process.env['CROWD_API_SERVICE_URL']}/member/${memberId}/unmerge/preview`
   const requestOptions = {
@@ -72,9 +71,7 @@ export async function unmergeMembersPreview(
       'Content-Type': 'application/json',
     },
     data: {
-      platform: memberIdentity.platform,
-      value: memberIdentity.value,
-      type: memberIdentity.type,
+      identityId,
     },
   }
 

--- a/services/apps/script_executor_worker/src/workflows/dissectMember.ts
+++ b/services/apps/script_executor_worker/src/workflows/dissectMember.ts
@@ -6,7 +6,7 @@ import {
   startChild,
 } from '@temporalio/workflow'
 
-import { IMemberUnmergeBackup, IUnmergeBackup, MemberIdentityType } from '@crowd/types'
+import { IMemberUnmergeBackup, IUnmergeBackup } from '@crowd/types'
 
 import * as commonActivities from '../activities/common'
 import * as activities from '../activities/dissect-member'
@@ -50,12 +50,7 @@ export async function dissectMember(args: IDissectMemberArgs): Promise<void> {
 
     for (const groupedIdentities of memberIdentitiesGroupedByPlatform) {
       // 1. get payload for identity split using unmergePreview endpoint
-      const preview = await common.unmergeMembersPreview(args.memberId, {
-        platform: groupedIdentities.platforms[0],
-        type: groupedIdentities.types[0] as MemberIdentityType,
-        verified: groupedIdentities.verified[0],
-        value: groupedIdentities.values[0],
-      })
+      const preview = await common.unmergeMembersPreview(args.memberId, groupedIdentities.ids[0])
       // 2. Currently unmerge preview only supports a single identity as input. Add grouped identities to secondary payload
       // and remove the grouped identities from the primary payload
       const toMove = preview.primary.identities.filter(

--- a/services/libs/data-access-layer/src/old/apps/script_executor_worker/member.repo.ts
+++ b/services/libs/data-access-layer/src/old/apps/script_executor_worker/member.repo.ts
@@ -116,6 +116,7 @@ class MemberRepository {
       rows = await this.connection.query(
         `
         select 
+          array_agg(mi.id) as ids,
           array_agg(mi.platform) as platforms, 
           array_agg(mi.type) as types,
           array_agg(mi.verified) as verified,

--- a/services/libs/data-access-layer/src/old/apps/script_executor_worker/types.ts
+++ b/services/libs/data-access-layer/src/old/apps/script_executor_worker/types.ts
@@ -15,6 +15,7 @@ export interface IFindMemberMergeActionReplacement {
 }
 
 export interface IFindMemberIdentitiesGroupedByPlatformResult {
+  ids: string[]
   platforms: string[]
   types: string[]
   verified: boolean[]


### PR DESCRIPTION
## Summary
`dissectMember` force-split was calling unmerge preview with `platform` / `value` / `type`. That endpoint only accepts `identityId` (same as the UI), so preview failed with "Identity not found".

## Changes
- Grouped-identities query now returns identity ids
- Force-split preview sends `{ identityId }` instead of the identity triple