### PR TITLE
fix: connectors worker temporal deps [CM-1446]

### DIFF
--- a/scripts/services/docker/Dockerfile.connectors_worker
+++ b/scripts/services/docker/Dockerfile.connectors_worker
@@ -1,6 +1,6 @@
-FROM node:24-alpine as builder
+FROM node:24-bookworm-slim as builder
 
-RUN apk add --no-cache python3 make g++
+RUN apt-get update && apt-get install -y python3 make g++ --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/crowd/app
 RUN npm install -g corepack@latest && corepack enable pnpm && corepack prepare pnpm@9.15.0 --activate


### PR DESCRIPTION
This pull request updates the base image and package installation method in the `Dockerfile.connectors_worker` to improve compatibility and maintainability.

**Docker image and dependency management updates:**

* Changed the base image from `node:24-alpine` to `node:24-bookworm-slim` for better compatibility with certain dependencies.
* Replaced `apk` package manager commands with `apt-get` to match the new Debian-based image, ensuring required build tools (`python3`, `make`, `g++`) are installed correctly.